### PR TITLE
Auto-updating Spryker modules on 2023-12-12 15:15

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -18671,16 +18671,16 @@
         },
         {
             "name": "spryker/chart",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/chart.git",
-                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b"
+                "reference": "96c11005add3af78dfc11baf0e7d60061104233d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/chart/zipball/d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
-                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
+                "url": "https://api.github.com/repos/spryker/chart/zipball/96c11005add3af78dfc11baf0e7d60061104233d",
+                "reference": "96c11005add3af78dfc11baf0e7d60061104233d",
                 "shasum": ""
             },
             "require": {
@@ -18717,9 +18717,9 @@
             ],
             "description": "Chart module",
             "support": {
-                "source": "https://github.com/spryker/chart/tree/1.5.0"
+                "source": "https://github.com/spryker/chart/tree/1.6.0"
             },
-            "time": "2023-10-09T14:30:57+00:00"
+            "time": "2023-11-01T12:11:03+00:00"
         },
         {
             "name": "spryker/chart-gui",

--- a/composer.lock
+++ b/composer.lock
@@ -465,16 +465,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -524,9 +524,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -542,7 +542,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -613,16 +613,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
                 "shasum": ""
             },
             "require": {
@@ -654,9 +654,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
             },
-            "time": "2023-06-03T09:27:29+00:00"
+            "time": "2023-09-27T20:04:15+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1255,22 +1255,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.7.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -1279,11 +1279,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1361,7 +1361,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1377,7 +1377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T14:04:53+00:00"
+            "time": "2023-12-03T20:35:24+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1460,16 +1460,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
                 "shasum": ""
             },
             "require": {
@@ -1483,9 +1483,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1556,7 +1556,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
             },
             "funding": [
                 {
@@ -1572,7 +1572,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-12-03T20:05:35+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1706,22 +1706,22 @@
         },
         {
             "name": "laminas/laminas-config",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0"
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/46baad58d0b12cf98539e04334eff40a1fdfb9a0",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/e53717277f6c22b1c697a46473b9a5ec9a438efa",
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -1770,7 +1770,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T14:21:22+00:00"
+            "time": "2023-09-19T12:02:54+00:00"
         },
         {
             "name": "laminas/laminas-filter",
@@ -2979,16 +2979,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
                 "shasum": ""
             },
             "require": {
@@ -3065,7 +3065,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.1"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
             },
             "funding": [
                 {
@@ -3077,7 +3077,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-06T13:44:46+00:00"
+            "time": "2023-10-27T15:25:26+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -3901,16 +3901,16 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
@@ -3947,9 +3947,9 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2023-04-10T20:12:12+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -4245,16 +4245,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.4",
+            "version": "4.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286"
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/60a4c63ab724854332900504274f6150ff26d286",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
                 "shasum": ""
             },
             "require": {
@@ -4321,7 +4321,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.4"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
             },
             "funding": [
                 {
@@ -4333,27 +4333,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-15T23:01:58+00:00"
+            "time": "2023-11-08T05:53:05+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -4397,7 +4397,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
@@ -4405,7 +4405,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-05-02T15:15:43+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "riskio/oauth2-auth0",
@@ -7575,16 +7575,16 @@
         },
         {
             "name": "spryker-sdk/evaluator",
-            "version": "0.1.3",
+            "version": "0.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/evaluator.git",
-                "reference": "3a4b3c85c00aea0514a98367317b4929ad7f6318"
+                "reference": "cdd63f1a0b44ec82f37d1644f9981cf93d9a357a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/evaluator/zipball/3a4b3c85c00aea0514a98367317b4929ad7f6318",
-                "reference": "3a4b3c85c00aea0514a98367317b4929ad7f6318",
+                "url": "https://api.github.com/repos/spryker-sdk/evaluator/zipball/cdd63f1a0b44ec82f37d1644f9981cf93d9a357a",
+                "reference": "cdd63f1a0b44ec82f37d1644f9981cf93d9a357a",
                 "shasum": ""
             },
             "require": {
@@ -7595,6 +7595,7 @@
                 "guzzlehttp/guzzle": "^7.5",
                 "php": ">=7.4",
                 "spryker-sdk/security-checker": "^0.2.0",
+                "spryker-sdk/utils": "^0.1.1",
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dotenv": "^5.4|^6.0",
                 "symfony/filesystem": "^5.4|^6.0",
@@ -7643,9 +7644,9 @@
             "description": "The tool for evaluating Spryker shops",
             "support": {
                 "issues": "https://github.com/spryker-sdk/evaluator/issues",
-                "source": "https://github.com/spryker-sdk/evaluator/tree/0.1.3"
+                "source": "https://github.com/spryker-sdk/evaluator/tree/0.1.15"
             },
-            "time": "2023-07-25T09:03:46+00:00"
+            "time": "2023-11-16T15:12:17+00:00"
         },
         {
             "name": "spryker-sdk/security-checker",
@@ -7694,6 +7695,53 @@
                 "source": "https://github.com/spryker-sdk/security-checker/tree/0.2.0"
             },
             "time": "2023-04-24T11:24:18+00:00"
+        },
+        {
+            "name": "spryker-sdk/utils",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker-sdk/utils.git",
+                "reference": "a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker-sdk/utils/zipball/a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2",
+                "reference": "a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.4",
+                "ext-mbstring": "*",
+                "laminas/laminas-filter": "^2.22.0",
+                "php": ">=7.4",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/filesystem": "^5.4.0 || ^6.0.0",
+                "symfony/finder": "^5.4.0 || ^6.0.0",
+                "symfony/process": "^5.4.0 || ^6.0.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "phpstan/phpstan": "^1.0.0",
+                "phpunit/phpunit": "^9.5.0",
+                "spryker/code-sniffer": "0.17.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SprykerSdk\\Utils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "Spryker SDK Utils Module",
+            "support": {
+                "issues": "https://github.com/spryker-sdk/utils/issues",
+                "source": "https://github.com/spryker-sdk/utils/tree/0.1.2"
+            },
+            "time": "2023-12-04T17:07:52+00:00"
         },
         {
             "name": "spryker-shop/agent-page",
@@ -15323,16 +15371,16 @@
         },
         {
             "name": "spryker/application",
-            "version": "3.32.1",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/application.git",
-                "reference": "86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8"
+                "reference": "103ae41d2fe45641d6ec295990ff5c789cb1bee6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/application/zipball/86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8",
-                "reference": "86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8",
+                "url": "https://api.github.com/repos/spryker/application/zipball/103ae41d2fe45641d6ec295990ff5c789cb1bee6",
+                "reference": "103ae41d2fe45641d6ec295990ff5c789cb1bee6",
                 "shasum": ""
             },
             "require": {
@@ -15346,7 +15394,7 @@
                 "spryker/log": "^3.1.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/symfony": "^3.5.0",
+                "spryker/symfony": "^3.9.0",
                 "spryker/twig": "^3.13.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -15384,9 +15432,9 @@
             ],
             "description": "Application module",
             "support": {
-                "source": "https://github.com/spryker/application/tree/3.32.1"
+                "source": "https://github.com/spryker/application/tree/3.34.0"
             },
-            "time": "2023-06-30T14:52:52+00:00"
+            "time": "2023-10-20T11:09:01+00:00"
         },
         {
             "name": "spryker/application-extension",
@@ -15931,16 +15979,16 @@
         },
         {
             "name": "spryker/availability",
-            "version": "9.18.0",
+            "version": "9.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/availability.git",
-                "reference": "8b69d070335433a1483934cc65cd798c6e98a510"
+                "reference": "ca1b297e7181a45183d614236d5b6f7b50f7c41a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/availability/zipball/8b69d070335433a1483934cc65cd798c6e98a510",
-                "reference": "8b69d070335433a1483934cc65cd798c6e98a510",
+                "url": "https://api.github.com/repos/spryker/availability/zipball/ca1b297e7181a45183d614236d5b6f7b50f7c41a",
+                "reference": "ca1b297e7181a45183d614236d5b6f7b50f7c41a",
                 "shasum": ""
             },
             "require": {
@@ -15948,6 +15996,7 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/availability-extension": "^1.2.0",
                 "spryker/decimal-object": "^1.0.0",
+                "spryker/dynamic-entity-extension": "^1.0.0",
                 "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
@@ -15963,7 +16012,7 @@
                 "spryker/storage": "^3.0.0",
                 "spryker/store": "^1.19.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/wishlist-extension": "^1.2.0",
                 "spryker/zed-request": "^3.0.0"
             },
@@ -15996,9 +16045,9 @@
             ],
             "description": "Availability module",
             "support": {
-                "source": "https://github.com/spryker/availability/tree/9.18.0"
+                "source": "https://github.com/spryker/availability/tree/9.20.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-01T10:06:20+00:00"
         },
         {
             "name": "spryker/availability-cart-connector",
@@ -17877,16 +17926,16 @@
         },
         {
             "name": "spryker/category",
-            "version": "5.13.0",
+            "version": "5.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/category.git",
-                "reference": "aca6a3df5617e5daab1daf68892dbcc3da10c249"
+                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/category/zipball/aca6a3df5617e5daab1daf68892dbcc3da10c249",
-                "reference": "aca6a3df5617e5daab1daf68892dbcc3da10c249",
+                "url": "https://api.github.com/repos/spryker/category/zipball/09187a8265547b2ef1493c03353c8a29a317fea0",
+                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0",
                 "shasum": ""
             },
             "require": {
@@ -17928,9 +17977,9 @@
             ],
             "description": "Category module",
             "support": {
-                "source": "https://github.com/spryker/category/tree/5.13.0"
+                "source": "https://github.com/spryker/category/tree/5.14.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-30T14:48:01+00:00"
         },
         {
             "name": "spryker/category-data-feed",
@@ -18622,16 +18671,16 @@
         },
         {
             "name": "spryker/chart",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/chart.git",
-                "reference": "095eb5c356c8513f5def6199a25e7ac487b7e111"
+                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/chart/zipball/095eb5c356c8513f5def6199a25e7ac487b7e111",
-                "reference": "095eb5c356c8513f5def6199a25e7ac487b7e111",
+                "url": "https://api.github.com/repos/spryker/chart/zipball/d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
+                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
                 "shasum": ""
             },
             "require": {
@@ -18668,9 +18717,9 @@
             ],
             "description": "Chart module",
             "support": {
-                "source": "https://github.com/spryker/chart/tree/1.4.0"
+                "source": "https://github.com/spryker/chart/tree/1.5.0"
             },
-            "time": "2023-04-06T11:39:54+00:00"
+            "time": "2023-10-09T14:30:57+00:00"
         },
         {
             "name": "spryker/chart-gui",
@@ -23805,16 +23854,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.51.4",
+            "version": "7.51.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "5986c56d94e35fa3b332a4dbb700efb4ef1f54f4"
+                "reference": "b89d545f5db90d7dc763d6de739e957025d9bbda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/5986c56d94e35fa3b332a4dbb700efb4ef1f54f4",
-                "reference": "5986c56d94e35fa3b332a4dbb700efb4ef1f54f4",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/b89d545f5db90d7dc763d6de739e957025d9bbda",
+                "reference": "b89d545f5db90d7dc763d6de739e957025d9bbda",
                 "shasum": ""
             },
             "require": {
@@ -23881,9 +23930,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.51.4"
+                "source": "https://github.com/spryker/customer/tree/7.51.6"
             },
-            "time": "2023-07-12T07:56:12+00:00"
+            "time": "2023-11-30T14:09:30+00:00"
         },
         {
             "name": "spryker/customer-access",
@@ -25813,6 +25862,48 @@
             "time": "2022-05-16T14:55:23+00:00"
         },
         {
+            "name": "spryker/dynamic-entity-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/dynamic-entity-extension.git",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/dynamic-entity-extension/zipball/bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "DynamicEntityExtension module",
+            "support": {
+                "source": "https://github.com/spryker/dynamic-entity-extension/tree/1.0.0"
+            },
+            "time": "2023-09-19T09:44:37+00:00"
+        },
+        {
             "name": "spryker/egulias",
             "version": "1.1.1",
             "source": {
@@ -25975,16 +26066,16 @@
         },
         {
             "name": "spryker/error-handler",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/error-handler.git",
-                "reference": "5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb"
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/error-handler/zipball/5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb",
-                "reference": "5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb",
+                "url": "https://api.github.com/repos/spryker/error-handler/zipball/a7df6c890b36982e0eaab1a65aa071d3c46c8236",
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236",
                 "shasum": ""
             },
             "require": {
@@ -26030,9 +26121,9 @@
             ],
             "description": "ErrorHandler module",
             "support": {
-                "source": "https://github.com/spryker/error-handler/tree/2.8.1"
+                "source": "https://github.com/spryker/error-handler/tree/2.9.0"
             },
-            "time": "2023-04-06T07:18:59+00:00"
+            "time": "2023-10-23T13:54:19+00:00"
         },
         {
             "name": "spryker/error-handler-extension",
@@ -27153,16 +27244,16 @@
         },
         {
             "name": "spryker/glossary-storage",
-            "version": "1.11.1",
+            "version": "1.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary-storage.git",
-                "reference": "7fcba040efc7cdde734c4e8d4357561ca58b9ba2"
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/7fcba040efc7cdde734c4e8d4357561ca58b9ba2",
-                "reference": "7fcba040efc7cdde734c4e8d4357561ca58b9ba2",
+                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
                 "shasum": ""
             },
             "require": {
@@ -27210,9 +27301,9 @@
             ],
             "description": "GlossaryStorage module",
             "support": {
-                "source": "https://github.com/spryker/glossary-storage/tree/1.11.1"
+                "source": "https://github.com/spryker/glossary-storage/tree/1.11.2"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-18T17:03:23+00:00"
         },
         {
             "name": "spryker/glue-application",
@@ -27935,16 +28026,16 @@
         },
         {
             "name": "spryker/gui",
-            "version": "3.49.2",
+            "version": "3.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/gui.git",
-                "reference": "e9f0c145a7064d1bbdbf6ac89a7295b21bed3632"
+                "reference": "d510351d3827ee75bed94f2692461ae074f0d0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/gui/zipball/e9f0c145a7064d1bbdbf6ac89a7295b21bed3632",
-                "reference": "e9f0c145a7064d1bbdbf6ac89a7295b21bed3632",
+                "url": "https://api.github.com/repos/spryker/gui/zipball/d510351d3827ee75bed94f2692461ae074f0d0b2",
+                "reference": "d510351d3827ee75bed94f2692461ae074f0d0b2",
                 "shasum": ""
             },
             "require": {
@@ -27993,9 +28084,9 @@
             ],
             "description": "Gui module",
             "support": {
-                "source": "https://github.com/spryker/gui/tree/3.49.2"
+                "source": "https://github.com/spryker/gui/tree/3.51.0"
             },
-            "time": "2023-04-06T07:25:58+00:00"
+            "time": "2023-09-22T10:20:19+00:00"
         },
         {
             "name": "spryker/gui-table",
@@ -28654,16 +28745,16 @@
         },
         {
             "name": "spryker/locale",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/locale.git",
-                "reference": "71be6de97df74807c0eeb2e848ec752366b246b5"
+                "reference": "d65201d202bb58790cd8872eae2d599040d14b45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/locale/zipball/71be6de97df74807c0eeb2e848ec752366b246b5",
-                "reference": "71be6de97df74807c0eeb2e848ec752366b246b5",
+                "url": "https://api.github.com/repos/spryker/locale/zipball/d65201d202bb58790cd8872eae2d599040d14b45",
+                "reference": "d65201d202bb58790cd8872eae2d599040d14b45",
                 "shasum": ""
             },
             "require": {
@@ -28676,7 +28767,8 @@
                 "spryker/propel-orm": "^1.8.0",
                 "spryker/store": "^1.19.0",
                 "spryker/store-extension": "^1.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/willdurand-negotiation": "^1.0.0",
                 "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
@@ -28717,9 +28809,9 @@
             ],
             "description": "Locale module",
             "support": {
-                "source": "https://github.com/spryker/locale/tree/4.1.0"
+                "source": "https://github.com/spryker/locale/tree/4.2.0"
             },
-            "time": "2023-07-11T10:55:36+00:00"
+            "time": "2023-10-17T16:01:45+00:00"
         },
         {
             "name": "spryker/locale-data-import",
@@ -32400,30 +32492,30 @@
         },
         {
             "name": "spryker/message-broker",
-            "version": "1.7.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker.git",
-                "reference": "2a914fc4ab70ecbe0646b866929f058d35184f8d"
+                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker/zipball/2a914fc4ab70ecbe0646b866929f058d35184f8d",
-                "reference": "2a914fc4ab70ecbe0646b866929f058d35184f8d",
+                "url": "https://api.github.com/repos/spryker/message-broker/zipball/39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
+                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/log": "^3.0.0",
-                "spryker/message-broker-extension": "^1.1.0",
+                "spryker/message-broker-extension": "^1.2.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/symfony": "^3.10.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-encoding": "^1.0.0 || ^2.0.0"
             },
             "require-dev": {
-                "spryker-sdk/async-api": "^0.2.0",
+                "spryker-sdk/async-api": "^0.3.0",
                 "spryker/application": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/console": "*",
@@ -32455,9 +32547,9 @@
             ],
             "description": "MessageBroker module",
             "support": {
-                "source": "https://github.com/spryker/message-broker/tree/1.7.0"
+                "source": "https://github.com/spryker/message-broker/tree/1.9.0"
             },
-            "time": "2023-06-22T09:38:01+00:00"
+            "time": "2023-08-31T11:27:42+00:00"
         },
         {
             "name": "spryker/message-broker-aws",
@@ -32521,16 +32613,16 @@
         },
         {
             "name": "spryker/message-broker-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker-extension.git",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298"
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/8360ac910ec5458e47ce4e3d6600073111d57298",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298",
+                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/c7fee41058388c635c07fd3787b451a2736340d1",
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1",
                 "shasum": ""
             },
             "require": {
@@ -32562,9 +32654,9 @@
             ],
             "description": "MessageBrokerExtension module",
             "support": {
-                "source": "https://github.com/spryker/message-broker-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/message-broker-extension/tree/1.2.0"
             },
-            "time": "2022-12-23T11:50:03+00:00"
+            "time": "2023-07-21T13:09:09+00:00"
         },
         {
             "name": "spryker/messenger",
@@ -34172,16 +34264,16 @@
         },
         {
             "name": "spryker/oms",
-            "version": "11.26.5",
+            "version": "11.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oms.git",
-                "reference": "7677ff2d756f73191c4b1df1fe2aed04146bd400"
+                "reference": "59b5c707d9d7fde1c57fed0ded576441f5e2d4aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oms/zipball/7677ff2d756f73191c4b1df1fe2aed04146bd400",
-                "reference": "7677ff2d756f73191c4b1df1fe2aed04146bd400",
+                "url": "https://api.github.com/repos/spryker/oms/zipball/59b5c707d9d7fde1c57fed0ded576441f5e2d4aa",
+                "reference": "59b5c707d9d7fde1c57fed0ded576441f5e2d4aa",
                 "shasum": ""
             },
             "require": {
@@ -34238,9 +34330,9 @@
             ],
             "description": "Oms module",
             "support": {
-                "source": "https://github.com/spryker/oms/tree/11.26.5"
+                "source": "https://github.com/spryker/oms/tree/11.27.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-08-21T15:35:01+00:00"
         },
         {
             "name": "spryker/oms-discount-connector",
@@ -36538,16 +36630,16 @@
         },
         {
             "name": "spryker/product",
-            "version": "6.36.3",
+            "version": "6.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product.git",
-                "reference": "a1c280f867e5e3f8844eb2e01d8dea9723fc8c01"
+                "reference": "4e4cb5700ec4340d9a3cc87c350fe4d40e044b33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product/zipball/a1c280f867e5e3f8844eb2e01d8dea9723fc8c01",
-                "reference": "a1c280f867e5e3f8844eb2e01d8dea9723fc8c01",
+                "url": "https://api.github.com/repos/spryker/product/zipball/4e4cb5700ec4340d9a3cc87c350fe4d40e044b33",
+                "reference": "4e4cb5700ec4340d9a3cc87c350fe4d40e044b33",
                 "shasum": ""
             },
             "require": {
@@ -36597,9 +36689,9 @@
             ],
             "description": "Product module",
             "support": {
-                "source": "https://github.com/spryker/product/tree/6.36.3"
+                "source": "https://github.com/spryker/product/tree/6.37.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-08-11T07:36:13+00:00"
         },
         {
             "name": "spryker/product-abstract-data-feed",
@@ -39641,16 +39733,16 @@
         },
         {
             "name": "spryker/product-image",
-            "version": "3.16.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-image.git",
-                "reference": "768d310f354c7b3230f85aa9814c325dbb759b7d"
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-image/zipball/768d310f354c7b3230f85aa9814c325dbb759b7d",
-                "reference": "768d310f354c7b3230f85aa9814c325dbb759b7d",
+                "url": "https://api.github.com/repos/spryker/product-image/zipball/ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
                 "shasum": ""
             },
             "require": {
@@ -39688,9 +39780,9 @@
             ],
             "description": "ProductImage module",
             "support": {
-                "source": "https://github.com/spryker/product-image/tree/3.16.0"
+                "source": "https://github.com/spryker/product-image/tree/3.17.0"
             },
-            "time": "2023-04-17T15:49:27+00:00"
+            "time": "2023-07-17T12:04:54+00:00"
         },
         {
             "name": "spryker/product-image-cart-connector",
@@ -45366,16 +45458,16 @@
         },
         {
             "name": "spryker/router",
-            "version": "1.15.1",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/router.git",
-                "reference": "0021d531a083230819cd72d0f693727b6f0630f5"
+                "reference": "8eaf4245ce7e8e742726f596fa5431fe9fc936f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/router/zipball/0021d531a083230819cd72d0f693727b6f0630f5",
-                "reference": "0021d531a083230819cd72d0f693727b6f0630f5",
+                "url": "https://api.github.com/repos/spryker/router/zipball/8eaf4245ce7e8e742726f596fa5431fe9fc936f8",
+                "reference": "8eaf4245ce7e8e742726f596fa5431fe9fc936f8",
                 "shasum": ""
             },
             "require": {
@@ -45419,9 +45511,9 @@
             ],
             "description": "Router module",
             "support": {
-                "source": "https://github.com/spryker/router/tree/1.15.1"
+                "source": "https://github.com/spryker/router/tree/1.17.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-10T10:57:01+00:00"
         },
         {
             "name": "spryker/router-extension",
@@ -45473,16 +45565,16 @@
         },
         {
             "name": "spryker/sales",
-            "version": "11.40.5",
+            "version": "11.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales.git",
-                "reference": "50e134623b85dfe29e5292aa6eb5a42ee259deb9"
+                "reference": "cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales/zipball/50e134623b85dfe29e5292aa6eb5a42ee259deb9",
-                "reference": "50e134623b85dfe29e5292aa6eb5a42ee259deb9",
+                "url": "https://api.github.com/repos/spryker/sales/zipball/cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99",
+                "reference": "cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99",
                 "shasum": ""
             },
             "require": {
@@ -45548,9 +45640,9 @@
             ],
             "description": "Sales module",
             "support": {
-                "source": "https://github.com/spryker/sales/tree/11.40.5"
+                "source": "https://github.com/spryker/sales/tree/11.41.0"
             },
-            "time": "2023-07-07T11:59:09+00:00"
+            "time": "2023-09-27T12:20:15+00:00"
         },
         {
             "name": "spryker/sales-configurable-bundle",
@@ -47422,16 +47514,16 @@
         },
         {
             "name": "spryker/search",
-            "version": "8.20.0",
+            "version": "8.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search.git",
-                "reference": "7d611a3672526f4341eb15db73f5f84d7a85fe50"
+                "reference": "ed45907ec596f9222fc7fb07f4e728bc316833b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search/zipball/7d611a3672526f4341eb15db73f5f84d7a85fe50",
-                "reference": "7d611a3672526f4341eb15db73f5f84d7a85fe50",
+                "url": "https://api.github.com/repos/spryker/search/zipball/ed45907ec596f9222fc7fb07f4e728bc316833b5",
+                "reference": "ed45907ec596f9222fc7fb07f4e728bc316833b5",
                 "shasum": ""
             },
             "require": {
@@ -47484,9 +47576,9 @@
             ],
             "description": "Search module",
             "support": {
-                "source": "https://github.com/spryker/search/tree/8.20.0"
+                "source": "https://github.com/spryker/search/tree/8.21.1"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-09-11T11:36:57+00:00"
         },
         {
             "name": "spryker/search-elasticsearch",
@@ -47605,16 +47697,16 @@
         },
         {
             "name": "spryker/search-extension",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search-extension.git",
-                "reference": "deed18da2ba98f335272ffc4f78eb56851ede2ba"
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search-extension/zipball/deed18da2ba98f335272ffc4f78eb56851ede2ba",
-                "reference": "deed18da2ba98f335272ffc4f78eb56851ede2ba",
+                "url": "https://api.github.com/repos/spryker/search-extension/zipball/149f7e2e993067718af9170eabc45fb58a255fda",
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda",
                 "shasum": ""
             },
             "require": {
@@ -47645,9 +47737,9 @@
             ],
             "description": "SearchExtension module",
             "support": {
-                "source": "https://github.com/spryker/search-extension/tree/1.2.0"
+                "source": "https://github.com/spryker/search-extension/tree/1.3.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-09-11T11:36:57+00:00"
         },
         {
             "name": "spryker/search-http",
@@ -49282,22 +49374,22 @@
         },
         {
             "name": "spryker/shipment",
-            "version": "8.15.2",
+            "version": "8.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment.git",
-                "reference": "f36ddcbe915591f59a041efac02d12842b7a974e"
+                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment/zipball/f36ddcbe915591f59a041efac02d12842b7a974e",
-                "reference": "f36ddcbe915591f59a041efac02d12842b7a974e",
+                "url": "https://api.github.com/repos/spryker/shipment/zipball/8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
+                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
-                "spryker/calculation": "^4.8.0",
+                "spryker/calculation": "^4.9.0",
                 "spryker/calculation-extension": "^1.0.0",
                 "spryker/country": "^3.0.0 || ^4.0.0",
                 "spryker/currency": "^3.1.0 || ^4.0.0",
@@ -49310,7 +49402,7 @@
                 "spryker/sales": "^11.25.0",
                 "spryker/sales-extension": "^1.6.0",
                 "spryker/session": "^3.0.0 || ^4.0.0",
-                "spryker/shipment-extension": "^1.1.0",
+                "spryker/shipment-extension": "^1.2.0",
                 "spryker/store": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax": "^5.0.0",
@@ -49348,9 +49440,9 @@
             ],
             "description": "Shipment module",
             "support": {
-                "source": "https://github.com/spryker/shipment/tree/8.15.2"
+                "source": "https://github.com/spryker/shipment/tree/8.18.0"
             },
-            "time": "2023-06-06T15:14:45+00:00"
+            "time": "2023-10-25T07:06:24+00:00"
         },
         {
             "name": "spryker/shipment-cart-connector",
@@ -49554,20 +49646,21 @@
         },
         {
             "name": "spryker/shipment-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment-extension.git",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a"
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
+                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/60944ddd7eb0cb42da0e37ff3953590353434ba3",
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -49589,9 +49682,9 @@
             ],
             "description": "ShipmentExtension module",
             "support": {
-                "source": "https://github.com/spryker/shipment-extension/tree/master"
+                "source": "https://github.com/spryker/shipment-extension/tree/1.2.0"
             },
-            "time": "2020-03-11T14:56:31+00:00"
+            "time": "2023-08-01T09:25:56+00:00"
         },
         {
             "name": "spryker/shipment-gui",
@@ -50178,16 +50271,16 @@
         },
         {
             "name": "spryker/stock",
-            "version": "8.8.2",
+            "version": "8.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/stock.git",
-                "reference": "7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8"
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/stock/zipball/7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8",
-                "reference": "7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8",
+                "url": "https://api.github.com/repos/spryker/stock/zipball/5261ab0f27009e6e3bae8d9edc44b83f52353138",
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138",
                 "shasum": ""
             },
             "require": {
@@ -50226,9 +50319,9 @@
             ],
             "description": "Stock module",
             "support": {
-                "source": "https://github.com/spryker/stock/tree/8.8.2"
+                "source": "https://github.com/spryker/stock/tree/8.8.3"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-07-25T12:51:44+00:00"
         },
         {
             "name": "spryker/stock-address",
@@ -50464,16 +50557,16 @@
         },
         {
             "name": "spryker/storage",
-            "version": "3.20.1",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/storage.git",
-                "reference": "e18aa318532a53831a66ff406ba4529119091b01"
+                "reference": "826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/storage/zipball/e18aa318532a53831a66ff406ba4529119091b01",
-                "reference": "e18aa318532a53831a66ff406ba4529119091b01",
+                "url": "https://api.github.com/repos/spryker/storage/zipball/826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2",
+                "reference": "826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2",
                 "shasum": ""
             },
             "require": {
@@ -50524,9 +50617,9 @@
             ],
             "description": "Storage module",
             "support": {
-                "source": "https://github.com/spryker/storage/tree/3.20.1"
+                "source": "https://github.com/spryker/storage/tree/3.21.0"
             },
-            "time": "2023-07-12T09:45:07+00:00"
+            "time": "2023-07-24T13:36:15+00:00"
         },
         {
             "name": "spryker/storage-database",
@@ -50761,16 +50854,16 @@
         },
         {
             "name": "spryker/store",
-            "version": "1.20.0",
+            "version": "1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/store.git",
-                "reference": "a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c"
+                "reference": "d0d3009c346c1f785ee455ee98b1e47dd8e1044a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/store/zipball/a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c",
-                "reference": "a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c",
+                "url": "https://api.github.com/repos/spryker/store/zipball/d0d3009c346c1f785ee455ee98b1e47dd8e1044a",
+                "reference": "d0d3009c346c1f785ee455ee98b1e47dd8e1044a",
                 "shasum": ""
             },
             "require": {
@@ -50786,6 +50879,7 @@
                 "spryker/store-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
+                "spryker/zed-request": "^3.3.0",
                 "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
@@ -50819,9 +50913,9 @@
             ],
             "description": "Store module",
             "support": {
-                "source": "https://github.com/spryker/store/tree/1.20.0"
+                "source": "https://github.com/spryker/store/tree/1.23.1"
             },
-            "time": "2023-05-22T19:10:17+00:00"
+            "time": "2023-08-31T11:27:42+00:00"
         },
         {
             "name": "spryker/store-context-gui",
@@ -52011,16 +52105,16 @@
         },
         {
             "name": "spryker/twig",
-            "version": "3.18.1",
+            "version": "3.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/twig.git",
-                "reference": "07aa6395bd84fd14567c15a3f8c77a55bff0268a"
+                "reference": "7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/twig/zipball/07aa6395bd84fd14567c15a3f8c77a55bff0268a",
-                "reference": "07aa6395bd84fd14567c15a3f8c77a55bff0268a",
+                "url": "https://api.github.com/repos/spryker/twig/zipball/7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce",
+                "reference": "7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce",
                 "shasum": ""
             },
             "require": {
@@ -52065,9 +52159,9 @@
             ],
             "description": "Twig module",
             "support": {
-                "source": "https://github.com/spryker/twig/tree/3.18.1"
+                "source": "https://github.com/spryker/twig/tree/3.18.2"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-07-27T15:38:05+00:00"
         },
         {
             "name": "spryker/twig-extension",
@@ -52925,16 +53019,16 @@
         },
         {
             "name": "spryker/util-date-time",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-date-time.git",
-                "reference": "1dc77bf90621976dfb0858f1baf420459ccbfac1"
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/1dc77bf90621976dfb0858f1baf420459ccbfac1",
-                "reference": "1dc77bf90621976dfb0858f1baf420459ccbfac1",
+                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/01a1c0ca748c9d04faaa2dc404a2232132157962",
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962",
                 "shasum": ""
             },
             "require": {
@@ -52970,9 +53064,9 @@
             ],
             "description": "UtilDateTime module",
             "support": {
-                "source": "https://github.com/spryker/util-date-time/tree/1.4.0"
+                "source": "https://github.com/spryker/util-date-time/tree/1.4.1"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-07-27T15:38:05+00:00"
         },
         {
             "name": "spryker/util-encoding",
@@ -53878,6 +53972,40 @@
             "time": "2021-07-07T15:14:17+00:00"
         },
         {
+            "name": "spryker/willdurand-negotiation",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/willdurand-negotiation.git",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/willdurand-negotiation/zipball/d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "willdurand/negotiation": "^2.3.0 || ^3.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "WilldurandNegotiation module",
+            "support": {
+                "source": "https://github.com/spryker/willdurand-negotiation/tree/1.0.0"
+            },
+            "time": "2023-10-17T16:01:45+00:00"
+        },
+        {
             "name": "spryker/wishlist",
             "version": "8.7.3",
             "source": {
@@ -54182,16 +54310,16 @@
         },
         {
             "name": "spryker/zed-request",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-request.git",
-                "reference": "bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446"
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-request/zipball/bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446",
-                "reference": "bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446",
+                "url": "https://api.github.com/repos/spryker/zed-request/zipball/b06b5e843f8b3406436b0567dc6dd6581725fa1a",
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a",
                 "shasum": ""
             },
             "require": {
@@ -54247,9 +54375,9 @@
             ],
             "description": "ZedRequest module",
             "support": {
-                "source": "https://github.com/spryker/zed-request/tree/3.19.0"
+                "source": "https://github.com/spryker/zed-request/tree/3.20.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-19T09:26:16+00:00"
         },
         {
             "name": "spryker/zed-request-extension",
@@ -55606,16 +55734,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v2.3.1",
+            "version": "v2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "3c9c3424efdafe33e0e3cfb5e87e50b34711fedf"
+                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/3c9c3424efdafe33e0e3cfb5e87e50b34711fedf",
-                "reference": "3c9c3424efdafe33e0e3cfb5e87e50b34711fedf",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
+                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
                 "shasum": ""
             },
             "require": {
@@ -55651,7 +55779,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v2.3.1"
+                "source": "https://github.com/symfony/flex/tree/v2.4.2"
             },
             "funding": [
                 {
@@ -55667,7 +55795,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-27T07:38:25+00:00"
+            "time": "2023-12-05T14:09:35+00:00"
         },
         {
             "name": "symfony/form",
@@ -56590,16 +56718,16 @@
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v5.4.22",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a"
+                "reference": "3e295d9b0a873476356cb6cff0ce39b3f528b387"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/34be6f0695e4187dbb832a05905fb4c6581ac39a",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/3e295d9b0a873476356cb6cff0ce39b3f528b387",
+                "reference": "3e295d9b0a873476356cb6cff0ce39b3f528b387",
                 "shasum": ""
             },
             "require": {
@@ -56654,7 +56782,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v5.4.22"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -56670,34 +56798,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-10-31T07:58:33+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v3.8.0",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d"
+                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d",
-                "reference": "a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
+                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "^1.22 || ^2.0 || ^3.0",
-                "php": ">=7.1.3",
-                "symfony/config": "~4.4 || ^5.0 || ^6.0",
-                "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-                "symfony/http-kernel": "~4.4 || ^5.0 || ^6.0",
-                "symfony/monolog-bridge": "~4.4 || ^5.0 || ^6.0"
+                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
+                "php": ">=7.2.5",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+                "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0"
             },
             "require-dev": {
-                "symfony/console": "~4.4 || ^5.0 || ^6.0",
-                "symfony/phpunit-bridge": "^5.2 || ^6.0",
-                "symfony/yaml": "~4.4 || ^5.0 || ^6.0"
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^6.3 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -56735,7 +56863,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v3.8.0"
+                "source": "https://github.com/symfony/monolog-bundle/tree/v3.10.0"
             },
             "funding": [
                 {
@@ -56751,7 +56879,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T14:24:36+00:00"
+            "time": "2023-11-06T17:08:13+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -56894,16 +57022,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -56915,7 +57043,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -56955,7 +57083,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -56971,20 +57099,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c"
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e46b4da57951a16053cd751f63f4a24292788157",
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157",
                 "shasum": ""
             },
             "require": {
@@ -56996,7 +57124,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57042,7 +57170,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57058,20 +57186,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-03-21T17:27:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
                 "shasum": ""
             },
             "require": {
@@ -57085,7 +57213,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57129,7 +57257,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57145,20 +57273,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:30:37+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -57170,7 +57298,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57213,7 +57341,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57229,20 +57357,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -57257,7 +57385,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57296,7 +57424,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57312,20 +57440,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -57334,7 +57462,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57375,7 +57503,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57391,20 +57519,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -57413,7 +57541,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57458,7 +57586,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57474,20 +57602,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
                 "shasum": ""
             },
             "require": {
@@ -57496,7 +57624,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57537,7 +57665,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57553,20 +57681,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166"
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/f3cf1a645c2734236ed1e2e671e273eeb3586166",
-                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e",
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e",
                 "shasum": ""
             },
             "require": {
@@ -57581,7 +57709,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -57619,7 +57747,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -57635,7 +57763,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/process",
@@ -58032,16 +58160,16 @@
         },
         {
             "name": "symfony/security-core",
-            "version": "v5.4.22",
+            "version": "v5.4.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "a801d525c7545332e2ddf7f52c163959354b1650"
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/a801d525c7545332e2ddf7f52c163959354b1650",
-                "reference": "a801d525c7545332e2ddf7f52c163959354b1650",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/3908c54da30dd68c2fe31915d82a1c81809d1928",
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928",
                 "shasum": ""
             },
             "require": {
@@ -58105,7 +58233,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v5.4.22"
+                "source": "https://github.com/symfony/security-core/tree/v5.4.30"
             },
             "funding": [
                 {
@@ -58121,7 +58249,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-10T10:02:45+00:00"
+            "time": "2023-10-27T07:38:28+00:00"
         },
         {
             "name": "symfony/security-csrf",
@@ -58196,20 +58324,21 @@
         },
         {
             "name": "symfony/security-guard",
-            "version": "v5.4.22",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-guard.git",
-                "reference": "62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa"
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-guard/zipball/62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa",
-                "reference": "62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa",
+                "url": "https://api.github.com/repos/symfony/security-guard/zipball/72c53142533462fc6fda4a429c2a21c2b944a8cc",
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-php80": "^1.15",
                 "symfony/security-core": "^5.0",
                 "symfony/security-http": "^5.3"
@@ -58243,7 +58372,7 @@
             "description": "Symfony Security Component - Guard",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-guard/tree/v5.4.22"
+                "source": "https://github.com/symfony/security-guard/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -58259,20 +58388,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-07-28T14:44:35+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v5.4.23",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "6791856229cc605834d169091981e4eae77dad45"
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/6791856229cc605834d169091981e4eae77dad45",
-                "reference": "6791856229cc605834d169091981e4eae77dad45",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/6d3cd5a4deee9697738db8d24258890ca4140ae9",
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9",
                 "shasum": ""
             },
             "require": {
@@ -58283,7 +58412,8 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/property-access": "^4.4|^5.0|^6.0",
-                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5"
+                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5",
+                "symfony/service-contracts": "^1.10|^2|^3"
             },
             "conflict": {
                 "symfony/event-dispatcher": "<4.3",
@@ -58328,7 +58458,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v5.4.23"
+                "source": "https://github.com/symfony/security-http/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -58344,7 +58474,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T11:34:27+00:00"
+            "time": "2023-11-03T16:13:08+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -59388,26 +59518,27 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.6.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd"
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -59443,7 +59574,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.6.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -59455,20 +59586,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-08T12:52:13+00:00"
+            "time": "2023-11-21T18:54:41+00:00"
         },
         {
             "name": "voku/anti-xss",
-            "version": "4.1.41",
+            "version": "4.1.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/anti-xss.git",
-                "reference": "55a403436494e44a2547a8d42de68e6cad4bca1d"
+                "reference": "bca1f8607e55a3c5077483615cd93bd8f11bd675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/anti-xss/zipball/55a403436494e44a2547a8d42de68e6cad4bca1d",
-                "reference": "55a403436494e44a2547a8d42de68e6cad4bca1d",
+                "url": "https://api.github.com/repos/voku/anti-xss/zipball/bca1f8607e55a3c5077483615cd93bd8f11bd675",
+                "reference": "bca1f8607e55a3c5077483615cd93bd8f11bd675",
                 "shasum": ""
             },
             "require": {
@@ -59514,7 +59645,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/anti-xss/issues",
-                "source": "https://github.com/voku/anti-xss/tree/4.1.41"
+                "source": "https://github.com/voku/anti-xss/tree/4.1.42"
             },
             "funding": [
                 {
@@ -59538,7 +59669,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-12T15:56:55+00:00"
+            "time": "2023-07-03T14:40:46+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -61152,16 +61283,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.2",
+            "version": "2.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73"
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546",
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546",
                 "shasum": ""
             },
             "require": {
@@ -61211,7 +61342,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.2"
+                "source": "https://github.com/filp/whoops/tree/2.15.4"
             },
             "funding": [
                 {
@@ -61219,7 +61350,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-12T12:00:00+00:00"
+            "time": "2023-11-03T12:00:00+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -62493,16 +62624,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.22.1",
+            "version": "1.24.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0"
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/65c39594fbd8c67abfc68bb323f86447bab79cc0",
-                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6bd0c26f3786cd9b7c359675cb789e35a8e07496",
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496",
                 "shasum": ""
             },
             "require": {
@@ -62534,9 +62665,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.4"
             },
-            "time": "2023-06-29T20:46:06+00:00"
+            "time": "2023-11-26T18:29:22+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -65636,5 +65767,5 @@
     "platform-overrides": {
         "php": "8.0.9"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -676,6 +676,7 @@ $config[OmsConstants::PROCESS_LOCATION] = [
     OmsConfig::DEFAULT_PROCESS_LOCATION,
     APPLICATION_ROOT_DIR . '/vendor/spryker/sales-payment/config/Zed/Oms',
     APPLICATION_ROOT_DIR . '/vendor/spryker/payment/config/Zed/Oms',
+    APPLICATION_ROOT_DIR . '/vendor/spryker/payment/config/Zed/Oms',
 ];
 $config[OmsConstants::ACTIVE_PROCESSES] = [
     'ForeignPaymentB2CStateMachine01',

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -675,12 +675,15 @@ $config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = getenv('
 $config[OmsConstants::PROCESS_LOCATION] = [
     OmsConfig::DEFAULT_PROCESS_LOCATION,
     APPLICATION_ROOT_DIR . '/vendor/spryker/sales-payment/config/Zed/Oms',
+    APPLICATION_ROOT_DIR . '/vendor/spryker/payment/config/Zed/Oms',
 ];
 $config[OmsConstants::ACTIVE_PROCESSES] = [
     'ForeignPaymentB2CStateMachine01',
 ];
 $config[SalesConstants::PAYMENT_METHOD_STATEMACHINE_MAPPING] = [
     PaymentConfig::PAYMENT_FOREIGN_PROVIDER => 'ForeignPaymentB2CStateMachine01',
+    \SprykerEco\Zed\Payone\PayoneConfig::PAYMENT_METHOD_CREDIT_CARD => 'PayoneCreditCardPartialOperations',
+    \SprykerEco\Zed\Payone\PayoneConfig::PAYMENT_METHOD_INSTANT_ONLINE_TRANSFER => 'PayoneOnlineTransferPartialOperations',
 ];
 
 // ----------------------------------------------------------------------------
@@ -839,3 +842,28 @@ $config[GlueJsonApiConventionConstants::GLUE_DOMAIN] = sprintf(
     $sprykerGlueStorefrontHost ?: $sprykerGlueBackendHost ?: 'localhost',
 );
 $config[GlueStorefrontApiApplicationConstants::GLUE_STOREFRONT_CORS_ALLOW_ORIGIN] = getenv('SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN') ?: '*';
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::CHANNEL_TO_RECEIVER_TRANSPORT_MAP] = [
+    'payment-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'payment-method-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'asset-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-review-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'search-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'merchant-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+];
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::CHANNEL_TO_SENDER_TRANSPORT_MAP] = [
+    'payment-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'order-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'merchant-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+];
+
+$config[\Spryker\Shared\Product\ProductConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';
+
+$config[\Spryker\Shared\PropelReplicationCache\PropelReplicationCacheConstants::IS_REPLICATION_ENABLED] = (bool)$config[\Spryker\Shared\Propel\PropelConstants::ZED_DB_REPLICAS];
+
+$config[\Spryker\Shared\SecurityBlocker\SecurityBlockerConstants::SECURITY_BLOCKER_AGENT_BLOCKING_TTL] = 900;

--- a/config/Zed/navigation.xml
+++ b/config/Zed/navigation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <config>
-    <!-- You can control navigation order here and add your custom navigation entries -->
     <dashboard>
         <label>Dashboard</label>
         <title>Dashboard</title>
@@ -367,7 +366,7 @@
     <app-catalog-gui>
         <label>Apps</label>
         <title>Apps</title>
-        <icon>fa-cubes</icon>
+        <icon>fa-archive</icon>
         <bundle>app-catalog-gui</bundle>
         <controller>index</controller>
         <action>index</action>

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -3108,3 +3108,5 @@ shipment_type.validation.store_does_not_exist,A store with the name ‘%name%’
 shipment_type.validation.store_does_not_exist,Store mit dem Namen ‘%name%’ existiert nicht.,de_DE
 store.validation.store_not_found,Store not found,en_US
 store.validation.store_not_found,Store nicht gefunden,de_DE
+security_blocker_backoffice_gui.error.account_blocked,"Warten Sie bitte %minutes% Minuten, bevor Sie es erneut versuchen.",de_DE
+security_blocker_merchant_portal_gui.error.account_blocked,"Warten Sie bitte %minutes% Minuten, bevor Sie es erneut versuchen.",de_DE

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -3078,3 +3078,33 @@ wishlist.validation.error.wishlist_item_cannot_be_updated,Wishlist item cannot b
 wishlist.validation.error.wishlist_item_cannot_be_updated,Wunschliste kann nicht aktualisiert werden.,de_DE
 store_widget.switcher.store,Store:,en_US
 store_widget.switcher.store,Shop:,de_DE
+merchant_product_offer_widget.merchant_name,Merchant,en_US
+merchant_product_offer_widget.merchant_name,Händler,de_DE
+product_configurator_gateway_page.shopping_list_item_uuid_required,Shopping List item ID is required parameter.,en_US
+product_configurator_gateway_page.shopping_list_item_uuid_required,Die Artikel-ID der Einkaufsliste ist ein erforderlicher Parameter.,de_DE
+customer.salutation.invalid,Salutation is invalid,en_US
+customer.salutation.invalid,Anrede ist ungültig,de_DE
+customer.billing_address.salutation.invalid,Salutation is invalid,en_US
+customer.billing_address.salutation.invalid,Anrede ist ungültig,de_DE
+customer.shipping_address.salutation.invalid,Salutation is invalid,en_US
+customer.shipping_address.salutation.invalid,Anrede ist ungültig,de_DE
+security_blocker_backoffice_gui.error.account_blocked,"Warten Sie bitte %minutes% Minuten, bevor Sie es erneut versuchen.",de_DE
+security_blocker_merchant_portal_gui.error.account_blocked,"Warten Sie bitte %minutes% Minuten, bevor Sie es erneut versuchen.",de_DE
+shipment_type.name.shipment_type_delivery,Delivery,en_US
+shipment_type.name.shipment_type_delivery,Lieferung,de_DE
+shipment_type.name.shipment_type_pickup,Pickup,en_US
+shipment_type.name.shipment_type_pickup,Abholung,de_DE
+shipment_type.validation.shipment_type_entity_not_found,A delivery type entity was not found.,en_US
+shipment_type.validation.shipment_type_entity_not_found,Lieferart wurde nicht gefunden.,de_DE
+shipment_type.validation.shipment_type_key_exists,A delivery type with the same key already exists.,en_US
+shipment_type.validation.shipment_type_key_exists,Es existiert bereits eine Lieferart mit dem gleichen Schlüssel.,de_DE
+shipment_type.validation.shipment_type_key_is_not_unique,At least two delivery types in this request have the same key.,en_US
+shipment_type.validation.shipment_type_key_is_not_unique,Mindestens zwei Lieferarten in dieser Anfrage haben den gleichen Schlüssel.,de_DE
+shipment_type.validation.shipment_type_key_invalid_length,A delivery type key must have a length from %min% to %max% characters.,en_US
+shipment_type.validation.shipment_type_key_invalid_length,Der Lieferart-Schlüssel muss eine Länge von %min% bis %max% Zeichen haben.,de_DE
+shipment_type.validation.shipment_type_name_invalid_length,A delivery type name must have a length from %min% to %max% characters.,en_US
+shipment_type.validation.shipment_type_name_invalid_length,Der Lieferart-Name muss eine Länge von %min% bis %max% Zeichen haben.,de_DE
+shipment_type.validation.store_does_not_exist,A store with the name ‘%name%’ does not exist.,en_US
+shipment_type.validation.store_does_not_exist,Store mit dem Namen ‘%name%’ existiert nicht.,de_DE
+store.validation.store_not_found,Store not found,en_US
+store.validation.store_not_found,Store nicht gefunden,de_DE

--- a/src/Pyz/Client/Authentication/AuthenticationDependencyProvider.php
+++ b/src/Pyz/Client/Authentication/AuthenticationDependencyProvider.php
@@ -21,4 +21,14 @@ class AuthenticationDependencyProvider extends SprykerAuthenticationDependencyPr
             new OauthAuthenticationServerPlugin(),
         ];
     }
+
+    /**
+     * @return array
+     */
+    public function getAuthenticationServerPlugin(): array
+    {
+        return [
+            new OauthAuthenticationServerPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Client/Cart/CartDependencyProvider.php
+++ b/src/Pyz/Client/Cart/CartDependencyProvider.php
@@ -8,13 +8,9 @@
 namespace Pyz\Client\Cart;
 
 use Spryker\Client\Cart\CartDependencyProvider as SprykerCartDependencyProvider;
-use Spryker\Client\Cart\Dependency\Plugin\ItemCountPluginInterface;
 use Spryker\Client\Cart\Plugin\ProductSeparateCartChangeExpanderPlugin;
-use Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
 use Spryker\Client\DiscountPromotion\Plugin\AddDiscountPromotionCartRequestExpandPlugin;
 use Spryker\Client\PersistentCart\Plugin\DatabaseQuoteStorageStrategy;
-use Spryker\Client\ProductBundle\Plugin\Cart\BundleProductQuoteItemFinderPlugin;
-use Spryker\Client\ProductBundle\Plugin\Cart\ProductBundleItemCountQuantityPlugin;
 use Spryker\Client\ProductBundle\Plugin\Cart\RemoveBundleChangeRequestExpanderPlugin;
 use Spryker\Client\ProductConfigurationCart\Plugin\Cart\ProductConfigurationCartChangeRequestExpanderPlugin;
 
@@ -23,7 +19,7 @@ class CartDependencyProvider extends SprykerCartDependencyProvider
     /**
      * @return \Spryker\Client\Cart\Dependency\Plugin\ItemCountPluginInterface
      */
-    protected function getItemCountPlugin(): ItemCountPluginInterface
+    protected function getItemCountPlugin(): ProductBundleItemCountQuantityPlugin
     {
         return new ProductBundleItemCountQuantityPlugin();
     }
@@ -42,7 +38,7 @@ class CartDependencyProvider extends SprykerCartDependencyProvider
     /**
      * @return \Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface
      */
-    protected function getQuoteItemFinderPlugin(): QuoteItemFinderPluginInterface
+    protected function getQuoteItemFinderPlugin(): BundleProductQuoteItemFinderPlugin
     {
         return new BundleProductQuoteItemFinderPlugin();
     }

--- a/src/Pyz/Client/Cart/CartDependencyProvider.php
+++ b/src/Pyz/Client/Cart/CartDependencyProvider.php
@@ -11,6 +11,8 @@ use Spryker\Client\Cart\CartDependencyProvider as SprykerCartDependencyProvider;
 use Spryker\Client\Cart\Plugin\ProductSeparateCartChangeExpanderPlugin;
 use Spryker\Client\DiscountPromotion\Plugin\AddDiscountPromotionCartRequestExpandPlugin;
 use Spryker\Client\PersistentCart\Plugin\DatabaseQuoteStorageStrategy;
+use Spryker\Client\ProductBundle\Plugin\Cart\BundleProductQuoteItemFinderPlugin;
+use Spryker\Client\ProductBundle\Plugin\Cart\ProductBundleItemCountQuantityPlugin;
 use Spryker\Client\ProductBundle\Plugin\Cart\RemoveBundleChangeRequestExpanderPlugin;
 use Spryker\Client\ProductConfigurationCart\Plugin\Cart\ProductConfigurationCartChangeRequestExpanderPlugin;
 

--- a/src/Pyz/Client/CartNote/CartNoteDependencyProvider.php
+++ b/src/Pyz/Client/CartNote/CartNoteDependencyProvider.php
@@ -8,6 +8,8 @@
 namespace Pyz\Client\CartNote;
 
 use Spryker\Client\CartNote\CartNoteDependencyProvider as SprykerCartNoteDependencyProvider;
+use Spryker\Client\CartNoteExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
+use Spryker\Client\CartNoteProductBundleConnector\Plugin\BundleProductQuoteItemFinderPlugin;
 
 class CartNoteDependencyProvider extends SprykerCartNoteDependencyProvider
 {

--- a/src/Pyz/Client/CartNote/CartNoteDependencyProvider.php
+++ b/src/Pyz/Client/CartNote/CartNoteDependencyProvider.php
@@ -8,8 +8,6 @@
 namespace Pyz\Client\CartNote;
 
 use Spryker\Client\CartNote\CartNoteDependencyProvider as SprykerCartNoteDependencyProvider;
-use Spryker\Client\CartNoteExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
-use Spryker\Client\CartNoteProductBundleConnector\Plugin\BundleProductQuoteItemFinderPlugin;
 
 class CartNoteDependencyProvider extends SprykerCartNoteDependencyProvider
 {
@@ -18,6 +16,6 @@ class CartNoteDependencyProvider extends SprykerCartNoteDependencyProvider
      */
     protected function getQuoteItemsFinderPlugin(): QuoteItemFinderPluginInterface
     {
-        return new BundleProductQuoteItemFinderPlugin(); #CartNoteFeature
+        return new BundleProductQuoteItemFinderPlugin();
     }
 }

--- a/src/Pyz/Client/Catalog/CatalogDependencyProvider.php
+++ b/src/Pyz/Client/Catalog/CatalogDependencyProvider.php
@@ -28,6 +28,7 @@ use Spryker\Client\CatalogPriceProductConnector\Plugin\ProductPriceQueryExpander
 use Spryker\Client\CategoryStorage\Plugin\Catalog\ResultFormatter\CategoryTreeFilterSearchHttpResultFormatterPlugin;
 use Spryker\Client\CategoryStorage\Plugin\Elasticsearch\ResultFormatter\CategoryTreeFilterPageSearchResultFormatterPlugin;
 use Spryker\Client\MerchantProductOfferSearch\Plugin\Search\MerchantReferenceQueryExpanderPlugin;
+use Spryker\Client\MerchantProductSearch\Plugin\Search\MerchantReferenceQueryExpanderPlugin as SprykerMerchantReferenceQueryExpanderPlugin;
 use Spryker\Client\ProductLabelStorage\Plugin\Catalog\ProductLabelSearchHttpFacetConfigTransferBuilderPlugin;
 use Spryker\Client\ProductLabelStorage\Plugin\ProductLabelFacetConfigTransferBuilderPlugin;
 use Spryker\Client\ProductListSearch\Plugin\Search\ProductListQueryExpanderPlugin;
@@ -215,6 +216,8 @@ class CatalogDependencyProvider extends SprykerCatalogDependencyProvider
             new LocalizedQueryExpanderPlugin(),
             new PaginatedProductConcreteCatalogSearchQueryExpanderPlugin(),
             new ProductListQueryExpanderPlugin(),
+            new MerchantReferenceQueryExpanderPlugin(),
+            new SprykerMerchantReferenceQueryExpanderPlugin(),
         ];
     }
 

--- a/src/Pyz/Client/ProductReview/ProductReviewDependencyProvider.php
+++ b/src/Pyz/Client/ProductReview/ProductReviewDependencyProvider.php
@@ -52,6 +52,7 @@ class ProductReviewDependencyProvider extends SprykerProductReviewDependencyProv
         $productReviewQueryExpanderPlugins = parent::getProductReviewsQueryExpanderPlugins();
         $productReviewQueryExpanderPlugins[] = new FilterByIdProductReviewQueryExpanderPlugin();
         $productReviewQueryExpanderPlugins[] = new FilterByIdProductReviewQueryExpanderPlugin();
+        $productReviewQueryExpanderPlugins[] = new FilterByIdProductReviewQueryExpanderPlugin();
 
         return $productReviewQueryExpanderPlugins;
     }

--- a/src/Pyz/Client/ProductReview/ProductReviewDependencyProvider.php
+++ b/src/Pyz/Client/ProductReview/ProductReviewDependencyProvider.php
@@ -51,6 +51,7 @@ class ProductReviewDependencyProvider extends SprykerProductReviewDependencyProv
     {
         $productReviewQueryExpanderPlugins = parent::getProductReviewsQueryExpanderPlugins();
         $productReviewQueryExpanderPlugins[] = new FilterByIdProductReviewQueryExpanderPlugin();
+        $productReviewQueryExpanderPlugins[] = new FilterByIdProductReviewQueryExpanderPlugin();
 
         return $productReviewQueryExpanderPlugins;
     }

--- a/src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php
+++ b/src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php
@@ -9,8 +9,10 @@ namespace Pyz\Glue\DocumentationGeneratorApi;
 
 use Spryker\Glue\DocumentationGeneratorApi\DocumentationGeneratorApiDependencyProvider as SprykerDocumentationGeneratorApiDependencyProvider;
 use Spryker\Glue\DocumentationGeneratorApi\Expander\ContextExpanderCollectionInterface;
+use Spryker\Glue\DocumentationGeneratorApiExtension\Dependency\Plugin\ContentGeneratorStrategyPluginInterface;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\ControllerAnnotationsContextExpanderPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\CustomRouteControllerAnnotationsContextExpanderPlugin;
+use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\DocumentationGeneratorOpenApiContentGeneratorStrategyPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\DocumentationGeneratorOpenApiSchemaFormatterPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\RelationshipPluginAnnotationsContextExpanderPlugin;
 use Spryker\Glue\GlueApplication\Plugin\DocumentationGeneratorApi\RestApiSchemaFormatterPlugin;
@@ -93,6 +95,41 @@ class DocumentationGeneratorApiDependencyProvider extends SprykerDocumentationGe
         $contextExpanderCollection->addExpander(new StorefrontAuthorizationContextExpanderPlugin(), [static::GLUE_STOREFRONT_API_APPLICATION_NAME]);
         $contextExpanderCollection->addExpander(new BackendAuthorizationContextExpanderPlugin(), [static::GLUE_BACKEND_API_APPLICATION_NAME]);
         $contextExpanderCollection->addExpander(new BackendRelationshipPluginsContextExpanderPlugin(), [static::GLUE_BACKEND_API_APPLICATION_NAME]);
+        $contextExpanderCollection->addExpander(new ControllerAnnotationsContextExpanderPlugin());
+        $contextExpanderCollection->addExpander(new CustomRouteControllerAnnotationsContextExpanderPlugin());
+        $contextExpanderCollection->addExpander(new RelationshipPluginAnnotationsContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendResourcesContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendCustomRoutesContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendHostContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new AuthorizationContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendRelationshipPluginsContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontResourcesContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontCustomRoutesContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontHostContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new SprykerAuthorizationContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new RelationshipPluginsContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
         $contextExpanderCollection->addExpander(new ControllerAnnotationsContextExpanderPlugin());
         $contextExpanderCollection->addExpander(new CustomRouteControllerAnnotationsContextExpanderPlugin());
         $contextExpanderCollection->addExpander(new RelationshipPluginAnnotationsContextExpanderPlugin(), [

--- a/src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php
+++ b/src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php
@@ -9,10 +9,8 @@ namespace Pyz\Glue\DocumentationGeneratorApi;
 
 use Spryker\Glue\DocumentationGeneratorApi\DocumentationGeneratorApiDependencyProvider as SprykerDocumentationGeneratorApiDependencyProvider;
 use Spryker\Glue\DocumentationGeneratorApi\Expander\ContextExpanderCollectionInterface;
-use Spryker\Glue\DocumentationGeneratorApiExtension\Dependency\Plugin\ContentGeneratorStrategyPluginInterface;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\ControllerAnnotationsContextExpanderPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\CustomRouteControllerAnnotationsContextExpanderPlugin;
-use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\DocumentationGeneratorOpenApiContentGeneratorStrategyPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\DocumentationGeneratorOpenApiSchemaFormatterPlugin;
 use Spryker\Glue\DocumentationGeneratorOpenApi\Plugin\DocumentationGeneratorApi\RelationshipPluginAnnotationsContextExpanderPlugin;
 use Spryker\Glue\GlueApplication\Plugin\DocumentationGeneratorApi\RestApiSchemaFormatterPlugin;
@@ -21,6 +19,7 @@ use Spryker\Glue\GlueBackendApiApplication\Plugin\DocumentationGeneratorApi\Back
 use Spryker\Glue\GlueBackendApiApplication\Plugin\DocumentationGeneratorApi\BackendHostContextExpanderPlugin;
 use Spryker\Glue\GlueBackendApiApplication\Plugin\DocumentationGeneratorApi\BackendResourcesContextExpanderPlugin;
 use Spryker\Glue\GlueBackendApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorApi\AuthorizationContextExpanderPlugin as BackendAuthorizationContextExpanderPlugin;
+use Spryker\Glue\GlueBackendApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorOpenApi\AuthorizationContextExpanderPlugin;
 use Spryker\Glue\GlueBackendApiApplicationGlueJsonApiConventionConnector\Plugin\DocumentationGeneratorApi\RelationshipPluginsContextExpanderPlugin as BackendRelationshipPluginsContextExpanderPlugin;
 use Spryker\Glue\GlueJsonApiConvention\Plugin\DocumentationGeneratorApi\JsonApiSchemaFormatterPlugin;
 use Spryker\Glue\GlueStorefrontApiApplication\Plugin\DocumentationGeneratorApi\StorefrontApiApplicationProviderPlugin;
@@ -28,6 +27,7 @@ use Spryker\Glue\GlueStorefrontApiApplication\Plugin\DocumentationGeneratorApi\S
 use Spryker\Glue\GlueStorefrontApiApplication\Plugin\DocumentationGeneratorApi\StorefrontHostContextExpanderPlugin;
 use Spryker\Glue\GlueStorefrontApiApplication\Plugin\DocumentationGeneratorApi\StorefrontResourcesContextExpanderPlugin;
 use Spryker\Glue\GlueStorefrontApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorApi\AuthorizationContextExpanderPlugin as StorefrontAuthorizationContextExpanderPlugin;
+use Spryker\Glue\GlueStorefrontApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorOpenApi\AuthorizationContextExpanderPlugin as SprykerAuthorizationContextExpanderPlugin;
 use Spryker\Glue\GlueStorefrontApiApplicationGlueJsonApiConventionConnector\Plugin\GlueStorefrontApiApplication\RelationshipPluginsContextExpanderPlugin;
 
 class DocumentationGeneratorApiDependencyProvider extends SprykerDocumentationGeneratorApiDependencyProvider
@@ -72,7 +72,9 @@ class DocumentationGeneratorApiDependencyProvider extends SprykerDocumentationGe
      */
     protected function getContextExpanderPlugins(ContextExpanderCollectionInterface $contextExpanderCollection): ContextExpanderCollectionInterface
     {
-        $apiApplications = [];
+        $apiApplications = [
+            $this->getApiApplicationProviderPlugins(),
+        ];
         foreach ($this->getApiApplicationProviderPlugins() as $apiApplicationProviderPlugin) {
             $apiApplications[] = $apiApplicationProviderPlugin->getName();
         }
@@ -91,6 +93,41 @@ class DocumentationGeneratorApiDependencyProvider extends SprykerDocumentationGe
         $contextExpanderCollection->addExpander(new StorefrontAuthorizationContextExpanderPlugin(), [static::GLUE_STOREFRONT_API_APPLICATION_NAME]);
         $contextExpanderCollection->addExpander(new BackendAuthorizationContextExpanderPlugin(), [static::GLUE_BACKEND_API_APPLICATION_NAME]);
         $contextExpanderCollection->addExpander(new BackendRelationshipPluginsContextExpanderPlugin(), [static::GLUE_BACKEND_API_APPLICATION_NAME]);
+        $contextExpanderCollection->addExpander(new ControllerAnnotationsContextExpanderPlugin());
+        $contextExpanderCollection->addExpander(new CustomRouteControllerAnnotationsContextExpanderPlugin());
+        $contextExpanderCollection->addExpander(new RelationshipPluginAnnotationsContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendResourcesContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendCustomRoutesContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendHostContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new AuthorizationContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new BackendRelationshipPluginsContextExpanderPlugin(), [
+            static::GLUE_BACKEND_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontResourcesContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontCustomRoutesContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new StorefrontHostContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new SprykerAuthorizationContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
+        $contextExpanderCollection->addExpander(new RelationshipPluginsContextExpanderPlugin(), [
+            static::GLUE_STOREFRONT_API_APPLICATION_NAME,
+        ]);
 
         return $contextExpanderCollection;
     }

--- a/src/Pyz/Glue/GlueApplication/GlueApplicationDependencyProvider.php
+++ b/src/Pyz/Glue/GlueApplication/GlueApplicationDependencyProvider.php
@@ -36,6 +36,7 @@ use Spryker\Glue\CartsRestApi\CartsRestApiConfig;
 use Spryker\Glue\CartsRestApi\Plugin\ControllerBeforeAction\SetAnonymousCustomerIdControllerBeforeActionPlugin;
 use Spryker\Glue\CartsRestApi\Plugin\GlueApplication\CartByRestCheckoutDataResourceRelationshipPlugin;
 use Spryker\Glue\CartsRestApi\Plugin\GlueApplication\CartItemsByQuoteResourceRelationshipPlugin;
+use Spryker\Glue\CartsRestApi\Plugin\GlueApplication\ExpandRequestWithCustomerReferenceFormattedControllerBeforeActionPlugin;
 use Spryker\Glue\CartsRestApi\Plugin\GlueApplication\GuestCartByRestCheckoutDataResourceRelationshipPlugin;
 use Spryker\Glue\CartsRestApi\Plugin\GlueApplication\GuestCartItemsByQuoteResourceRelationshipPlugin;
 use Spryker\Glue\CartsRestApi\Plugin\ResourceRoute\CartItemsResourceRoutePlugin;
@@ -326,6 +327,7 @@ class GlueApplicationDependencyProvider extends SprykerGlueApplicationDependency
     {
         return [
             new FormattedControllerBeforeActionValidateAccessTokenPlugin(),
+            new ExpandRequestWithCustomerReferenceFormattedControllerBeforeActionPlugin(),
         ];
     }
 

--- a/src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php
+++ b/src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php
@@ -21,6 +21,7 @@ use Spryker\Glue\OauthBackendApi\Plugin\AccessTokenValidatorPlugin;
 use Spryker\Glue\OauthBackendApi\Plugin\GlueApplication\OauthBackendApiTokenResource;
 use Spryker\Glue\OauthBackendApi\Plugin\GlueApplication\UserRequestValidatorPlugin;
 use Spryker\Glue\OauthBackendApi\Plugin\GlueBackendApiApplication\UserRequestBuilderPlugin;
+use Spryker\Glue\OauthBackendApi\Plugin\UserRequestValidatorPlugin as SprykerUserRequestValidatorPlugin;
 use Spryker\Glue\Router\Plugin\Application\RouterApplicationPlugin;
 use Spryker\Glue\StoresRestApi\Plugin\Application\StoreHttpHeaderApplicationPlugin;
 use Spryker\Zed\Propel\Communication\Plugin\Application\PropelApplicationPlugin;
@@ -61,6 +62,7 @@ class GlueBackendApiApplicationDependencyProvider extends SprykerGlueBackendApiA
         return [
             new AccessTokenValidatorPlugin(),
             new UserRequestValidatorPlugin(),
+            new SprykerUserRequestValidatorPlugin(),
         ];
     }
 

--- a/src/Pyz/Glue/GlueJsonApiConvention/GlueJsonApiConventionDependencyProvider.php
+++ b/src/Pyz/Glue/GlueJsonApiConvention/GlueJsonApiConventionDependencyProvider.php
@@ -9,7 +9,16 @@ namespace Pyz\Glue\GlueJsonApiConvention;
 
 use Spryker\Glue\GlueBackendApiApplicationGlueJsonApiConventionConnector\Plugin\GlueJsonApiConvention\BackendApiRelationshipProviderPlugin;
 use Spryker\Glue\GlueJsonApiConvention\GlueJsonApiConventionDependencyProvider as SprykerGlueJsonApiConventionDependencyProvider;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\AttributesRequestBuilderPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\ConventionIdentifierRequestBuilderPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\FilterFieldRequestBuilderPlugin;
 use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\FilterRequestValidatorPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\JsonApiResponseFormatterPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\PaginationRequestBuilderPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\RelationshipRequestBuilderPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\RelationshipResponseFormatterPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\SortRequestBuilderPlugin;
+use Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\SparseFieldRequestBuilderPlugin;
 use Spryker\Glue\GlueStorefrontApiApplicationGlueJsonApiConventionConnector\Plugin\GlueStorefrontApiApplication\StorefrontApiRelationshipProviderPlugin;
 
 class GlueJsonApiConventionDependencyProvider extends SprykerGlueJsonApiConventionDependencyProvider
@@ -32,6 +41,33 @@ class GlueJsonApiConventionDependencyProvider extends SprykerGlueJsonApiConventi
     {
         return [
             new FilterRequestValidatorPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\RequestBuilderPluginInterface>
+     */
+    protected function getRequestBuilderPlugins(): array
+    {
+        return [
+            new ConventionIdentifierRequestBuilderPlugin(),
+            new SparseFieldRequestBuilderPlugin(),
+            new AttributesRequestBuilderPlugin(),
+            new RelationshipRequestBuilderPlugin(),
+            new PaginationRequestBuilderPlugin(),
+            new SortRequestBuilderPlugin(),
+            new FilterFieldRequestBuilderPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResponseFormatterPluginInterface>
+     */
+    protected function getResponseFormatterPlugins(): array
+    {
+        return [
+            new RelationshipResponseFormatterPlugin(),
+            new JsonApiResponseFormatterPlugin(),
         ];
     }
 }

--- a/src/Pyz/Glue/GlueStorefrontApiApplication/GlueStorefrontApiApplicationDependencyProvider.php
+++ b/src/Pyz/Glue/GlueStorefrontApiApplication/GlueStorefrontApiApplicationDependencyProvider.php
@@ -15,10 +15,14 @@ use Spryker\Glue\GlueStorefrontApiApplication\Plugin\GlueApplication\ScopeReques
 use Spryker\Glue\GlueStorefrontApiApplication\Plugin\GlueApplication\SecurityHeaderResponseFormatterPlugin;
 use Spryker\Glue\GlueStorefrontApiApplication\Plugin\GlueApplication\StrictTransportSecurityHeaderResponseFormatterPlugin;
 use Spryker\Glue\GlueStorefrontApiApplicationAuthorizationConnector\Plugin\GlueStorefrontApiApplicationAuthorizationConnector\AuthorizationRequestAfterRoutingValidatorPlugin;
+use Spryker\Glue\Http\Plugin\Application\HttpApplicationPlugin;
+use Spryker\Glue\Locale\Plugin\Application\LocaleApplicationPlugin;
 use Spryker\Glue\OauthApi\Plugin\AccessTokenValidatorPlugin;
 use Spryker\Glue\OauthApi\Plugin\CustomerRequestBuilderPlugin;
+use Spryker\Glue\OauthApi\Plugin\CustomerRequestValidatorPlugin as SprykerCustomerRequestValidatorPlugin;
 use Spryker\Glue\OauthApi\Plugin\GlueApplication\CustomerRequestValidatorPlugin;
 use Spryker\Glue\OauthApi\Plugin\GlueApplication\OauthApiTokenResource;
+use Spryker\Glue\StoresRestApi\Plugin\Application\StoreHttpHeaderApplicationPlugin;
 
 class GlueStorefrontApiApplicationDependencyProvider extends SprykerGlueStorefrontApiApplicationDependencyProvider
 {
@@ -42,6 +46,7 @@ class GlueStorefrontApiApplicationDependencyProvider extends SprykerGlueStorefro
         return [
             new AccessTokenValidatorPlugin(),
             new CustomerRequestValidatorPlugin(),
+            new SprykerCustomerRequestValidatorPlugin(),
         ];
     }
 
@@ -84,5 +89,17 @@ class GlueStorefrontApiApplicationDependencyProvider extends SprykerGlueStorefro
     protected function getRouteProviderPlugins(): array
     {
         return [];
+    }
+
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getApplicationPlugins(): array
+    {
+        return [
+            new HttpApplicationPlugin(),
+            new LocaleApplicationPlugin(),
+            new StoreHttpHeaderApplicationPlugin(),
+        ];
     }
 }

--- a/src/Pyz/Service/Shipment/ShipmentConfig.php
+++ b/src/Pyz/Service/Shipment/ShipmentConfig.php
@@ -17,6 +17,6 @@ class ShipmentConfig extends SprykerShipmentConfig
      */
     public function getShipmentHashFields(): array
     {
-        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE]);
+        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE, ShipmentTransfer::SHIPMENT_TYPE_UUID]);
     }
 }

--- a/src/Pyz/Service/Shipment/ShipmentConfig.php
+++ b/src/Pyz/Service/Shipment/ShipmentConfig.php
@@ -17,6 +17,6 @@ class ShipmentConfig extends SprykerShipmentConfig
      */
     public function getShipmentHashFields(): array
     {
-        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE, ShipmentTransfer::SHIPMENT_TYPE_UUID]);
+        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE, ShipmentTransfer::SHIPMENT_TYPE_UUID, ShipmentTransfer::SHIPMENT_TYPE_UUID]);
     }
 }

--- a/src/Pyz/Shared/GlueBackendApiApplicationAuthorizationConnector/GlueBackendApiApplicationAuthorizationConnectorConfig.php
+++ b/src/Pyz/Shared/GlueBackendApiApplicationAuthorizationConnector/GlueBackendApiApplicationAuthorizationConnectorConfig.php
@@ -41,6 +41,12 @@ class GlueBackendApiApplicationAuthorizationConnectorConfig extends SprykerGlueB
                     'post',
                 ],
             ],
+            '/warehouse-tokens' => [
+                'isRegularExpression' => false,
+                'methods' => [
+                    'post',
+                ],
+            ],
         ];
     }
 }

--- a/src/Pyz/Shared/GlueBackendApiApplicationAuthorizationConnector/GlueBackendApiApplicationAuthorizationConnectorConfig.php
+++ b/src/Pyz/Shared/GlueBackendApiApplicationAuthorizationConnector/GlueBackendApiApplicationAuthorizationConnectorConfig.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Shared\GlueBackendApiApplicationAuthorizationConnector;
+
+use Spryker\Shared\GlueBackendApiApplicationAuthorizationConnector\GlueBackendApiApplicationAuthorizationConnectorConfig as SprykerGlueBackendApiApplicationAuthorizationConnectorConfig;
+
+class GlueBackendApiApplicationAuthorizationConnectorConfig extends SprykerGlueBackendApiApplicationAuthorizationConnectorConfig
+{
+    /**
+     * Specification:
+     * - Returns a list of protected endpoints.
+     * - Structure example:
+     * [
+     *      '/example' => [
+     *          'isRegularExpression' => false,
+     *      ],
+     *      '/\/example\/.+/' => [
+     *          'isRegularExpression' => true,
+     *          'methods' => [
+     *              'patch',
+     *              'delete',
+     *          ],
+     *      ],
+     * ]
+     *
+     * @api
+     *
+     * @return array<string, mixed>
+     */
+    public function getProtectedPaths(): array
+    {
+        return [
+            '/warehouse-tokens' => [
+                'isRegularExpression' => false,
+                'methods' => [
+                    'post',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Pyz/Shared/GlueStorefrontApiApplicationAuthorizationConnector/GlueStorefrontApiApplicationAuthorizationConnectorConfig.php
+++ b/src/Pyz/Shared/GlueStorefrontApiApplicationAuthorizationConnector/GlueStorefrontApiApplicationAuthorizationConnectorConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Shared\GlueStorefrontApiApplicationAuthorizationConnector;
+
+use Spryker\Shared\GlueStorefrontApiApplicationAuthorizationConnector\GlueStorefrontApiApplicationAuthorizationConnectorConfig as SprykerGlueStorefrontApiApplicationAuthorizationConnectorConfig;
+
+class GlueStorefrontApiApplicationAuthorizationConnectorConfig extends SprykerGlueStorefrontApiApplicationAuthorizationConnectorConfig
+{
+    /**
+     * Specification:
+     * - Returns a list of protected endpoints.
+     * - Structure example:
+     * [
+     *      '/example' => [
+     *          'isRegularExpression' => false,
+     *      ],
+     *      '/\/example\/.+/' => [
+     *          'isRegularExpression' => true,
+     *          'methods' => [
+     *              'patch',
+     *              'delete',
+     *          ],
+     *      ],
+     * ]
+     *
+     * @api
+     *
+     * @return array<string, mixed>
+     */
+    public function getProtectedPaths(): array
+    {
+        return [
+        ];
+    }
+}

--- a/src/Pyz/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
+++ b/src/Pyz/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
@@ -206,6 +206,7 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
     {
         return [
             new PaymentForeignHandlerPlugin(PaymentTransfer::FOREIGN_PAYMENTS),
+            new PaymentForeignHandlerPlugin(PaymentTransfer::FOREIGN_PAYMENTS),
         ];
     }
 }

--- a/src/Pyz/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
+++ b/src/Pyz/Yves/CheckoutPage/CheckoutPageDependencyProvider.php
@@ -198,4 +198,14 @@ class CheckoutPageDependencyProvider extends SprykerShopCheckoutPageDependencyPr
             new PaymentForeignPaymentCollectionExtenderPlugin(),
         ];
     }
+
+    /**
+     * @return array
+     */
+    public function extendPaymentMethodHandler(): array
+    {
+        return [
+            new PaymentForeignHandlerPlugin(PaymentTransfer::FOREIGN_PAYMENTS),
+        ];
+    }
 }

--- a/src/Pyz/Yves/CustomerReorderWidget/CustomerReorderWidgetDependencyProvider.php
+++ b/src/Pyz/Yves/CustomerReorderWidget/CustomerReorderWidgetDependencyProvider.php
@@ -8,6 +8,7 @@
 namespace Pyz\Yves\CustomerReorderWidget;
 
 use SprykerShop\Yves\CustomerReorderWidget\CustomerReorderWidgetDependencyProvider as SprykerCustomerReorderWidgetDependencyProvider;
+use SprykerShop\Yves\ProductBundleWidget\Plugin\CustomerReorderWidget\ProductBundleReorderItemFetcherPlugin;
 use SprykerShop\Yves\SalesConfigurableBundleWidget\Plugin\CustomerReorder\ConfiguredBundlePostReorderPlugin;
 use SprykerShop\Yves\SalesProductConfigurationWidget\Plugin\CustomerReorderWidget\ProductConfigurationReorderItemExpanderPlugin;
 use SprykerShop\Yves\SalesReturnPage\Plugin\CustomerReorderWidget\RemunerationAmountReorderItemSanitizerPlugin;
@@ -41,6 +42,16 @@ class CustomerReorderWidgetDependencyProvider extends SprykerCustomerReorderWidg
     {
         return [
             new RemunerationAmountReorderItemSanitizerPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\SprykerShop\Yves\CustomerReorderWidgetExtension\Dependency\Plugin\ReorderItemFetcherPluginInterface>
+     */
+    protected function getReorderItemFetcherPlugins(): array
+    {
+        return [
+            new ProductBundleReorderItemFetcherPlugin(),
         ];
     }
 }

--- a/src/Pyz/Yves/EventDispatcher/EventDispatcherDependencyProvider.php
+++ b/src/Pyz/Yves/EventDispatcher/EventDispatcherDependencyProvider.php
@@ -64,6 +64,7 @@ class EventDispatcherDependencyProvider extends SprykerEventDispatcherDependency
             new SecurityBlockerCustomerEventDispatcherPlugin(),
             new SecurityBlockerAgentEventDispatcherPlugin(),
             new EnvironmentInfoHeaderEventDispatcherPlugin(),
+            new ProfilerRequestEventDispatcherPlugin(),
         ];
 
         if (class_exists(ProfilerRequestEventDispatcherPlugin::class)) {

--- a/src/Pyz/Yves/MerchantProductOfferWidget/MerchantProductOfferWidgetDependencyProvider.php
+++ b/src/Pyz/Yves/MerchantProductOfferWidget/MerchantProductOfferWidgetDependencyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\MerchantProductOfferWidget;
+
+use SprykerShop\Yves\MerchantProductOfferWidget\MerchantProductOfferWidgetDependencyProvider as SprykerShopMerchantProductOfferWidgetDependencyProvider;
+use SprykerShop\Yves\MerchantProductWidget\Plugin\MerchantProductOfferWidget\MerchantProductMerchantProductOfferCollectionExpanderPlugin;
+
+class MerchantProductOfferWidgetDependencyProvider extends SprykerShopMerchantProductOfferWidgetDependencyProvider
+{
+    /**
+     * @return array<\SprykerShop\Yves\MerchantProductOfferWidgetExtension\Dependency\Plugin\MerchantProductOfferCollectionExpanderPluginInterface>
+     */
+    protected function getMerchantProductOfferCollectionExpanderPlugins(): array
+    {
+        return [
+            new MerchantProductMerchantProductOfferCollectionExpanderPlugin(),
+        ];
+    }
+}

--- a/src/Pyz/Yves/ProductSearchWidget/ProductSearchWidgetDependencyProvider.php
+++ b/src/Pyz/Yves/ProductSearchWidget/ProductSearchWidgetDependencyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\ProductSearchWidget;
+
+use SprykerShop\Yves\MerchantProductOfferWidget\Plugin\ProductSearchWidget\MerchantProductOfferProductQuickAddFormExpanderPlugin;
+use SprykerShop\Yves\ProductSearchWidget\ProductSearchWidgetDependencyProvider as SprykerShopProductSearchWidgetDependencyProvider;
+
+class ProductSearchWidgetDependencyProvider extends SprykerShopProductSearchWidgetDependencyProvider
+{
+    /**
+     * @return array<\SprykerShop\Yves\ProductSearchWidgetExtension\Dependency\Plugin\ProductQuickAddFormExpanderPluginInterface>
+     */
+    protected function getProductQuickAddFormExpanderPlugins(): array
+    {
+        return [
+            new MerchantProductOfferProductQuickAddFormExpanderPlugin(),
+        ];
+    }
+}

--- a/src/Pyz/Yves/Router/RouterDependencyProvider.php
+++ b/src/Pyz/Yves/Router/RouterDependencyProvider.php
@@ -39,6 +39,7 @@ use SprykerShop\Yves\DiscountWidget\Plugin\Router\DiscountWidgetRouteProviderPlu
 use SprykerShop\Yves\ErrorPage\Plugin\Router\ErrorPageRouteProviderPlugin;
 use SprykerShop\Yves\FileManagerWidget\Plugin\Router\FileManagerWidgetRouteProviderPlugin;
 use SprykerShop\Yves\HomePage\Plugin\Router\HomePageRouteProviderPlugin;
+use SprykerShop\Yves\MerchantProductOfferWidget\Plugin\Router\MerchantProductOfferWidgetRouteProviderPlugin;
 use SprykerShop\Yves\NewsletterPage\Plugin\Router\NewsletterPageRouteProviderPlugin;
 use SprykerShop\Yves\NewsletterWidget\Plugin\Router\NewsletterWidgetRouteProviderPlugin;
 use SprykerShop\Yves\OrderCancelWidget\Plugin\Router\OrderCancelWidgetRouteProviderPlugin;
@@ -112,6 +113,7 @@ class RouterDependencyProvider extends SprykerRouterDependencyProvider
             new OrderCancelWidgetRouteProviderPlugin(),
             new PaymentPageRouteProviderPlugin(),
             new ProductConfiguratorGatewayPageRouteProviderPlugin(),
+            new MerchantProductOfferWidgetRouteProviderPlugin(),
         ];
     }
 

--- a/src/Pyz/Yves/SessionAgentValidation/SessionAgentValidationDependencyProvider.php
+++ b/src/Pyz/Yves/SessionAgentValidation/SessionAgentValidationDependencyProvider.php
@@ -7,7 +7,11 @@
 
 namespace Pyz\Yves\SessionAgentValidation;
 
+use Spryker\Yves\SessionRedis\Plugin\SessionAgentValidation\SessionRedisSessionAgentSaverPlugin;
+use Spryker\Yves\SessionRedis\Plugin\SessionAgentValidation\SessionRedisSessionAgentValidatorPlugin;
 use SprykerShop\Yves\SessionAgentValidation\SessionAgentValidationDependencyProvider as SprykerSessionAgentValidationDependencyProvider;
+use SprykerShop\Yves\SessionAgentValidationExtension\Dependency\Plugin\SessionAgentSaverPluginInterface;
+use SprykerShop\Yves\SessionAgentValidationExtension\Dependency\Plugin\SessionAgentValidatorPluginInterface;
 
 class SessionAgentValidationDependencyProvider extends SprykerSessionAgentValidationDependencyProvider
 {

--- a/src/Pyz/Yves/SessionAgentValidation/SessionAgentValidationDependencyProvider.php
+++ b/src/Pyz/Yves/SessionAgentValidation/SessionAgentValidationDependencyProvider.php
@@ -7,11 +7,7 @@
 
 namespace Pyz\Yves\SessionAgentValidation;
 
-use Spryker\Yves\SessionRedis\Plugin\SessionAgentValidation\SessionRedisSessionAgentSaverPlugin;
-use Spryker\Yves\SessionRedis\Plugin\SessionAgentValidation\SessionRedisSessionAgentValidatorPlugin;
 use SprykerShop\Yves\SessionAgentValidation\SessionAgentValidationDependencyProvider as SprykerSessionAgentValidationDependencyProvider;
-use SprykerShop\Yves\SessionAgentValidationExtension\Dependency\Plugin\SessionAgentSaverPluginInterface;
-use SprykerShop\Yves\SessionAgentValidationExtension\Dependency\Plugin\SessionAgentValidatorPluginInterface;
 
 class SessionAgentValidationDependencyProvider extends SprykerSessionAgentValidationDependencyProvider
 {

--- a/src/Pyz/Yves/ShopApplication/ShopApplicationDependencyProvider.php
+++ b/src/Pyz/Yves/ShopApplication/ShopApplicationDependencyProvider.php
@@ -45,18 +45,22 @@ use SprykerShop\Yves\CurrencyWidget\Widget\CurrencyWidget;
 use SprykerShop\Yves\CustomerPage\Plugin\Application\CustomerConfirmationUserCheckerApplicationPlugin;
 use SprykerShop\Yves\CustomerPage\Widget\CustomerNavigationWidget;
 use SprykerShop\Yves\CustomerReorderWidget\Plugin\CustomerPage\CustomerReorderFormWidget;
-use SprykerShop\Yves\CustomerReorderWidget\Plugin\CustomerPage\CustomerReorderItemCheckboxWidget;
 use SprykerShop\Yves\CustomerReorderWidget\Plugin\CustomerPage\CustomerReorderItemsFormWidget;
+use SprykerShop\Yves\CustomerReorderWidget\Widget\CustomerReorderBundleItemCheckboxWidget;
+use SprykerShop\Yves\CustomerReorderWidget\Widget\CustomerReorderItemCheckboxWidget as SprykerShopCustomerReorderItemCheckboxWidget;
 use SprykerShop\Yves\CustomerValidationPage\Plugin\ShopApplication\LogoutInvalidatedCustomerFilterControllerEventHandlerPlugin;
 use SprykerShop\Yves\DiscountPromotionWidget\Plugin\ShopApplication\CartDiscountPromotionProductListWidgetCacheKeyGeneratorStrategyPlugin;
 use SprykerShop\Yves\DiscountPromotionWidget\Widget\CartDiscountPromotionProductListWidget;
 use SprykerShop\Yves\LanguageSwitcherWidget\Widget\LanguageSwitcherWidget;
 use SprykerShop\Yves\MerchantOpeningHoursWidget\Widget\MerchantOpeningHoursWidget;
+use SprykerShop\Yves\MerchantProductOfferWidget\Widget\MerchantProductOffersSelectWidget;
 use SprykerShop\Yves\MerchantProductOfferWidget\Widget\MerchantProductOfferWidget;
 use SprykerShop\Yves\MerchantProductWidget\Widget\MerchantProductWidget;
 use SprykerShop\Yves\MerchantSalesOrderWidget\Widget\MerchantOrderReferenceForItemsWidget;
 use SprykerShop\Yves\MerchantSalesReturnWidget\Plugin\MerchantSalesReturnCreateFormWidgetCacheKeyGeneratorStrategyPlugin;
 use SprykerShop\Yves\MerchantSalesReturnWidget\Widget\MerchantSalesReturnCreateFormWidget;
+use SprykerShop\Yves\MerchantSearchWidget\Widget\MerchantSearchWidget;
+use SprykerShop\Yves\MerchantWidget\Widget\MerchantMetaSchemaWidget;
 use SprykerShop\Yves\MerchantWidget\Widget\SoldByMerchantWidget;
 use SprykerShop\Yves\MoneyWidget\Widget\CurrencyIsoCodeWidget;
 use SprykerShop\Yves\NewsletterWidget\Widget\NewsletterSubscriptionSummaryWidget;
@@ -143,7 +147,6 @@ class ShopApplicationDependencyProvider extends SprykerShopApplicationDependency
             CurrencyWidget::class,
             CurrencyIsoCodeWidget::class,
             CustomerNavigationWidget::class,
-            CustomerReorderItemCheckboxWidget::class,
             DisplayProductAbstractReviewWidget::class,
             ProductGroupColorWidget::class,
             LanguageSwitcherWidget::class,
@@ -221,6 +224,12 @@ class ShopApplicationDependencyProvider extends SprykerShopApplicationDependency
             ProductConfigurationWishlistItemDisplayWidget::class,
             ProductConfigurationWishlistPageButtonWidget::class,
             StoreSwitcherWidget::class,
+            SprykerShopCustomerReorderItemCheckboxWidget::class,
+            CustomerReorderBundleItemCheckboxWidget::class,
+            MerchantProductOffersSelectWidget::class,
+            MerchantSearchWidget::class,
+            MerchantMetaSchemaWidget::class,
+            new StoreSwitcherWidget(),
         ];
     }
 

--- a/src/Pyz/Yves/WebProfilerWidget/WebProfilerWidgetDependencyProvider.php
+++ b/src/Pyz/Yves/WebProfilerWidget/WebProfilerWidgetDependencyProvider.php
@@ -46,6 +46,7 @@ class WebProfilerWidgetDependencyProvider extends SprykerWebProfilerDependencyPr
             new WebProfilerRedisDataCollectorPlugin(),
             new WebProfilerElasticsearchDataCollectorPlugin(),
             new WebProfilerZedRequestDataCollectorPlugin(),
+            new WebProfilerProfilerDataCollectorPlugin(),
         ];
 
         if (class_exists(WebProfilerProfilerDataCollectorPlugin::class)) {

--- a/src/Pyz/Zed/Authentication/AuthenticationDependencyProvider.php
+++ b/src/Pyz/Zed/Authentication/AuthenticationDependencyProvider.php
@@ -21,4 +21,14 @@ class AuthenticationDependencyProvider extends SprykerAuthenticationDependencyPr
             new OauthAuthenticationServerPlugin(),
         ];
     }
+
+    /**
+     * @return array
+     */
+    public function getAuthenticationServerPlugin(): array
+    {
+        return [
+            new OauthAuthenticationServerPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Zed/Authorization/AuthorizationDependencyProvider.php
+++ b/src/Pyz/Zed/Authorization/AuthorizationDependencyProvider.php
@@ -9,6 +9,7 @@ namespace Pyz\Zed\Authorization;
 
 use Spryker\Zed\Authorization\AuthorizationDependencyProvider as SprykerAuthorizationDependencyProvider;
 use Spryker\Zed\GlueBackendApiApplicationAuthorizationConnector\Communication\Plugin\Authorization\ProtectedPathAuthorizationStrategyPlugin;
+use Spryker\Zed\OauthWarehouse\Communication\Plugin\Authorization\WarehouseTokenAuthorizationStrategyPlugin;
 
 class AuthorizationDependencyProvider extends SprykerAuthorizationDependencyProvider
 {
@@ -19,6 +20,7 @@ class AuthorizationDependencyProvider extends SprykerAuthorizationDependencyProv
     {
         return [
             new ProtectedPathAuthorizationStrategyPlugin(),
+            new WarehouseTokenAuthorizationStrategyPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Cart/CartDependencyProvider.php
+++ b/src/Pyz/Zed/Cart/CartDependencyProvider.php
@@ -9,6 +9,7 @@ namespace Pyz\Zed\Cart;
 
 use Spryker\Zed\AvailabilityCartConnector\Communication\Plugin\Cart\CheckAvailabilityPlugin;
 use Spryker\Zed\Cart\CartDependencyProvider as SprykerCartDependencyProvider;
+use Spryker\Zed\Cart\Communication\Plugin\Cart\GroupKeyWithCartIdentifierItemExpanderPlugin;
 use Spryker\Zed\Cart\Communication\Plugin\CleanUpItemsPreReloadPlugin;
 use Spryker\Zed\Cart\Communication\Plugin\SkuGroupKeyPlugin;
 use Spryker\Zed\ConfigurableBundle\Communication\Plugin\Cart\CartConfigurableBundlePreReloadPlugin;
@@ -96,6 +97,7 @@ class CartDependencyProvider extends SprykerCartDependencyProvider
             new ProductOfferGroupKeyItemExpanderPlugin(),
             new MerchantShipmentItemExpanderPlugin(),
             new ProductConfigurationGroupKeyItemExpanderPlugin(),
+            new GroupKeyWithCartIdentifierItemExpanderPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/CartNote/CartNoteDependencyProvider.php
+++ b/src/Pyz/Zed/CartNote/CartNoteDependencyProvider.php
@@ -8,8 +8,6 @@
 namespace Pyz\Zed\CartNote;
 
 use Spryker\Zed\CartNote\CartNoteDependencyProvider as SprykerCartNoteDependencyProvider;
-use Spryker\Zed\CartNoteExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
-use Spryker\Zed\CartNoteProductBundleConnector\Communication\Plugin\BundleProductQuoteItemFinderPlugin;
 
 class CartNoteDependencyProvider extends SprykerCartNoteDependencyProvider
 {

--- a/src/Pyz/Zed/CartNote/CartNoteDependencyProvider.php
+++ b/src/Pyz/Zed/CartNote/CartNoteDependencyProvider.php
@@ -8,6 +8,8 @@
 namespace Pyz\Zed\CartNote;
 
 use Spryker\Zed\CartNote\CartNoteDependencyProvider as SprykerCartNoteDependencyProvider;
+use Spryker\Zed\CartNoteExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
+use Spryker\Zed\CartNoteProductBundleConnector\Communication\Plugin\BundleProductQuoteItemFinderPlugin;
 
 class CartNoteDependencyProvider extends SprykerCartNoteDependencyProvider
 {

--- a/src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php
+++ b/src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php
@@ -8,9 +8,9 @@
 namespace Pyz\Zed\CartsRestApi;
 
 use Spryker\Zed\CartsRestApi\CartsRestApiDependencyProvider as SprykerCartsRestApiDependencyProvider;
+use Spryker\Zed\CartsRestApiExtension\Dependency\Plugin\QuoteCreatorPluginInterface;
 use Spryker\Zed\DiscountPromotionsRestApi\Communication\Plugin\CartsRestApi\DiscountPromotionCartItemMapperPlugin;
 use Spryker\Zed\MerchantProductOffersRestApi\Communication\Plugin\CartsRestApi\MerchantProductOfferCartItemMapperPlugin;
-use Spryker\Zed\PersistentCart\Communication\Plugin\CartsRestApi\QuoteCreatorPlugin as SprykerQuoteCreatorPlugin;
 use Spryker\Zed\ProductBundleCartsRestApi\Communication\Plugin\BundleItemQuoteItemReadValidatorPlugin;
 use Spryker\Zed\ProductConfigurationsRestApi\Communication\Plugin\CartsRestApi\ProductConfigurationCartItemMapperPlugin;
 use Spryker\Zed\ProductOptionsRestApi\Communication\Plugin\CartsRestApi\ProductOptionCartItemMapperPlugin;

--- a/src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php
+++ b/src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php
@@ -8,10 +8,9 @@
 namespace Pyz\Zed\CartsRestApi;
 
 use Spryker\Zed\CartsRestApi\CartsRestApiDependencyProvider as SprykerCartsRestApiDependencyProvider;
-use Spryker\Zed\CartsRestApi\Communication\Plugin\CartsRestApi\QuoteCreatorPlugin;
-use Spryker\Zed\CartsRestApiExtension\Dependency\Plugin\QuoteCreatorPluginInterface;
 use Spryker\Zed\DiscountPromotionsRestApi\Communication\Plugin\CartsRestApi\DiscountPromotionCartItemMapperPlugin;
 use Spryker\Zed\MerchantProductOffersRestApi\Communication\Plugin\CartsRestApi\MerchantProductOfferCartItemMapperPlugin;
+use Spryker\Zed\PersistentCart\Communication\Plugin\CartsRestApi\QuoteCreatorPlugin as SprykerQuoteCreatorPlugin;
 use Spryker\Zed\ProductBundleCartsRestApi\Communication\Plugin\BundleItemQuoteItemReadValidatorPlugin;
 use Spryker\Zed\ProductConfigurationsRestApi\Communication\Plugin\CartsRestApi\ProductConfigurationCartItemMapperPlugin;
 use Spryker\Zed\ProductOptionsRestApi\Communication\Plugin\CartsRestApi\ProductOptionCartItemMapperPlugin;
@@ -24,7 +23,7 @@ class CartsRestApiDependencyProvider extends SprykerCartsRestApiDependencyProvid
      */
     protected function getQuoteCreatorPlugin(): QuoteCreatorPluginInterface
     {
-        return new QuoteCreatorPlugin();
+        return new SprykerQuoteCreatorPlugin();
     }
 
     /**

--- a/src/Pyz/Zed/Category/CategoryDependencyProvider.php
+++ b/src/Pyz/Zed/Category/CategoryDependencyProvider.php
@@ -8,9 +8,7 @@
 namespace Pyz\Zed\Category;
 
 use Spryker\Zed\Category\CategoryDependencyProvider as SprykerDependencyProvider;
-use Spryker\Zed\Category\Communication\Plugin\Category\MainChildrenPropagationCategoryStoreAssignerPlugin;
 use Spryker\Zed\Category\Communication\Plugin\CategoryUrlPathPrefixUpdaterPlugin;
-use Spryker\Zed\CategoryExtension\Dependency\Plugin\CategoryStoreAssignerPluginInterface;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetCreatorPlugin;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetExpanderPlugin;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetUpdaterPlugin;

--- a/src/Pyz/Zed/Category/CategoryDependencyProvider.php
+++ b/src/Pyz/Zed/Category/CategoryDependencyProvider.php
@@ -8,7 +8,9 @@
 namespace Pyz\Zed\Category;
 
 use Spryker\Zed\Category\CategoryDependencyProvider as SprykerDependencyProvider;
+use Spryker\Zed\Category\Communication\Plugin\Category\MainChildrenPropagationCategoryStoreAssignerPlugin;
 use Spryker\Zed\Category\Communication\Plugin\CategoryUrlPathPrefixUpdaterPlugin;
+use Spryker\Zed\CategoryExtension\Dependency\Plugin\CategoryStoreAssignerPluginInterface;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetCreatorPlugin;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetExpanderPlugin;
 use Spryker\Zed\CategoryImage\Communication\Plugin\CategoryImageSetUpdaterPlugin;

--- a/src/Pyz/Zed/Checkout/CheckoutDependencyProvider.php
+++ b/src/Pyz/Zed/Checkout/CheckoutDependencyProvider.php
@@ -10,7 +10,9 @@ namespace Pyz\Zed\Checkout;
 use Spryker\Zed\Availability\Communication\Plugin\ProductsAvailableCheckoutPreConditionPlugin;
 use Spryker\Zed\CartNote\Communication\Plugin\Checkout\CartNoteSaverPlugin;
 use Spryker\Zed\Checkout\CheckoutDependencyProvider as SprykerCheckoutDependencyProvider;
+use Spryker\Zed\Customer\Communication\Plugin\Checkout\CustomerAddressSalutationCheckoutPreConditionPlugin;
 use Spryker\Zed\Customer\Communication\Plugin\Checkout\CustomerOrderSavePlugin;
+use Spryker\Zed\Customer\Communication\Plugin\Checkout\CustomerSalutationCheckoutPreConditionPlugin;
 use Spryker\Zed\Customer\Communication\Plugin\CustomerPreConditionCheckerPlugin;
 use Spryker\Zed\Discount\Communication\Plugin\Checkout\DiscountOrderSavePlugin;
 use Spryker\Zed\Discount\Communication\Plugin\Checkout\VoucherDiscountMaxUsageCheckoutPreConditionPlugin;
@@ -39,6 +41,7 @@ use Spryker\Zed\Sales\Communication\Plugin\SalesOrderExpanderPlugin;
 use Spryker\Zed\SalesOrderThreshold\Communication\Plugin\Checkout\SalesOrderThresholdCheckoutPreConditionPlugin;
 use Spryker\Zed\SalesOrderThreshold\Communication\Plugin\Checkout\SalesOrderThresholdExpenseSavePlugin;
 use Spryker\Zed\SalesPayment\Communication\Plugin\Checkout\SalesPaymentCheckoutDoSaveOrderPlugin;
+use Spryker\Zed\SalesProductConfiguration\Communication\Plugin\Checkout\ProductConfigurationOrderSaverPlugin;
 use Spryker\Zed\Shipment\Communication\Plugin\Checkout\SalesOrderShipmentSavePlugin;
 use Spryker\Zed\ShipmentCheckoutConnector\Communication\Plugin\Checkout\ShipmentCheckoutPreCheckPlugin;
 
@@ -69,6 +72,8 @@ class CheckoutDependencyProvider extends SprykerCheckoutDependencyProvider
             new ProductExistsCheckoutPreConditionPlugin(),
             new ProductApprovalCheckoutPreConditionPlugin(),
             new ProductConfigurationCheckoutPreConditionPlugin(),
+            new CustomerSalutationCheckoutPreConditionPlugin(),
+            new CustomerAddressSalutationCheckoutPreConditionPlugin(),
         ];
     }
 
@@ -100,7 +105,8 @@ class CheckoutDependencyProvider extends SprykerCheckoutDependencyProvider
             new ProductBundleOrderSaverPlugin(),
             new SalesPaymentCheckoutDoSaveOrderPlugin(),
             new GiftCardCheckoutDoSaveOrderPlugin(),
-            new SalesOrderThresholdExpenseSavePlugin(), #SalesOrderThresholdFeature
+            new SalesOrderThresholdExpenseSavePlugin(),
+            new ProductConfigurationOrderSaverPlugin(), #SalesOrderThresholdFeature
         ];
     }
 

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -481,6 +481,7 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
         $applicationPlugins[] = new TwigApplicationPlugin();
         $applicationPlugins[] = new ConsoleLocaleApplicationPlugin();
         $applicationPlugins[] = new ConsoleLocaleApplicationPlugin();
+        $applicationPlugins[] = new ConsoleLocaleApplicationPlugin();
 
         return $applicationPlugins;
     }

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -146,6 +146,7 @@ use Spryker\Zed\SetupFrontend\Communication\Console\YvesInstallDependenciesConso
 use Spryker\Zed\SetupFrontend\Communication\Console\ZedBuildFrontendConsole;
 use Spryker\Zed\SetupFrontend\Communication\Console\ZedInstallDependenciesConsole;
 use Spryker\Zed\ShipmentDataImport\ShipmentDataImportConfig;
+use Spryker\Zed\ShipmentTypeDataImport\ShipmentTypeDataImportConfig;
 use Spryker\Zed\StateMachine\Communication\Console\CheckConditionConsole as StateMachineCheckConditionConsole;
 use Spryker\Zed\StateMachine\Communication\Console\CheckTimeoutConsole as StateMachineCheckTimeoutConsole;
 use Spryker\Zed\StateMachine\Communication\Console\ClearLocksConsole as StateMachineClearLocksConsole;
@@ -375,10 +376,25 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
             new MessageBrokerWorkerConsole(),
             new ScopeCacheCollectorConsole(),
             new DateTimeProductConfiguratorBuildFrontendConsole(),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . CountryDataImportConfig::IMPORT_TYPE_COUNTRY_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . CurrencyDataImportConfig::IMPORT_TYPE_CURRENCY_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . LocaleDataImportConfig::IMPORT_TYPE_LOCALE_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . LocaleDataImportConfig::IMPORT_TYPE_DEFAULT_LOCALE_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . StoreDataImportConfig::IMPORT_TYPE_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . ShipmentTypeDataImportConfig::IMPORT_TYPE_SHIPMENT_TYPE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . ShipmentTypeDataImportConfig::IMPORT_TYPE_SHIPMENT_TYPE_STORE),
+            new DataImportConsole(DataImportConsole::DEFAULT_NAME . static::COMMAND_SEPARATOR . ShipmentTypeDataImportConfig::IMPORT_TYPE_SHIPMENT_METHOD_SHIPMENT_TYPE),
         ];
 
         $propelCommands = $container->getLocator()->propel()->facade()->getConsoleCommands();
-        $commands = array_merge($commands, $propelCommands);
+        $commands = array_merge($commands, $propelCommands, [
+            new MessageBrokerDebugConsole(),
+            new MessageBrokerAwsSqsQueuesCreatorConsole(),
+            new MessageBrokerAwsSnsTopicsCreatorConsole(),
+            new MessageBrokerSqsToSnsSubscriberConsole(),
+            new GenerateGlueBackendIdeAutoCompletionConsole(),
+            new RemoveGlueBackendIdeAutoCompletionConsole(),
+        ]);
 
         if ($this->getConfig()->isPyzDevelopmentConsoleCommandsEnabled()) {
             $commands[] = new CodeTestConsole();
@@ -434,6 +450,9 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
             $commands[] = new MaintenanceEnableConsole();
             $commands[] = new MaintenanceDisableConsole();
         }
+        if ($this->getConfig()->isDevelopmentConsoleCommandsEnabled()) {
+            $commands[] = new MessageBrokerDebugConsole();
+        }
 
         return $commands;
     }
@@ -460,6 +479,7 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
         $applicationPlugins = parent::getApplicationPlugins($container);
         $applicationPlugins[] = new PropelApplicationPlugin();
         $applicationPlugins[] = new TwigApplicationPlugin();
+        $applicationPlugins[] = new ConsoleLocaleApplicationPlugin();
         $applicationPlugins[] = new ConsoleLocaleApplicationPlugin();
 
         return $applicationPlugins;

--- a/src/Pyz/Zed/Customer/Persistence/Propel/Schema/spy_customer.schema.xml
+++ b/src/Pyz/Zed/Customer/Persistence/Propel/Schema/spy_customer.schema.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
 <database xmlns="spryker:schema-01" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="zed" xsi:schemaLocation="spryker:schema-01 https://static.spryker.com/schema-01.xsd" namespace="Orm\Zed\Customer\Persistence" package="src.Orm.Zed.Customer.Persistence">
-
     <table name="spy_customer">
         <behavior name="event">
             <parameter name="spy_customer_anonymized_at" column="anonymized_at"/>
             <parameter name="spy_customer_password" column="password"/>
         </behavior>
     </table>
-
 </database>

--- a/src/Pyz/Zed/DataImport/DataImportDependencyProvider.php
+++ b/src/Pyz/Zed/DataImport/DataImportDependencyProvider.php
@@ -79,6 +79,9 @@ use Spryker\Zed\SalesReturnDataImport\Communication\Plugin\ReturnReasonDataImpor
 use Spryker\Zed\ShipmentDataImport\Communication\Plugin\ShipmentDataImportPlugin;
 use Spryker\Zed\ShipmentDataImport\Communication\Plugin\ShipmentMethodPriceDataImportPlugin;
 use Spryker\Zed\ShipmentDataImport\Communication\Plugin\ShipmentMethodStoreDataImportPlugin;
+use Spryker\Zed\ShipmentTypeDataImport\Communication\Plugin\DataImport\ShipmentMethodShipmentTypeDataImportPlugin;
+use Spryker\Zed\ShipmentTypeDataImport\Communication\Plugin\DataImport\ShipmentTypeDataImportPlugin;
+use Spryker\Zed\ShipmentTypeDataImport\Communication\Plugin\DataImport\ShipmentTypeStoreDataImportPlugin;
 use Spryker\Zed\StockAddressDataImport\Communication\Plugin\DataImport\StockAddressDataImportPlugin;
 use Spryker\Zed\StockDataImport\Communication\Plugin\StockDataImportPlugin;
 use Spryker\Zed\StockDataImport\Communication\Plugin\StockStoreDataImportPlugin;
@@ -377,6 +380,9 @@ class DataImportDependencyProvider extends SprykerDataImportDependencyProvider
             new MerchantProductApprovalStatusDefaultDataImportPlugin(),
             new ProductAbstractApprovalStatusDataImportPlugin(),
             new ProductConfigurationDataImportPlugin(),
+            new ShipmentTypeDataImportPlugin(),
+            new ShipmentTypeStoreDataImportPlugin(),
+            new ShipmentMethodShipmentTypeDataImportPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Discount/DiscountDependencyProvider.php
+++ b/src/Pyz/Zed/Discount/DiscountDependencyProvider.php
@@ -16,10 +16,11 @@ use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotio
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionCleanerPostUpdatePlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionCollectorStrategyPlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionConfigurationExpanderPlugin;
+use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionDiscountPostUpdatePlugin;
+use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionDiscountVoucherApplyCheckerStrategyPlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionFilterApplicableItemsPlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionFilterCollectedItemsPlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionPostCreatePlugin;
-use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionPostUpdatePlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\DiscountPromotionViewBlockProviderPlugin;
 use Spryker\Zed\DiscountPromotion\Communication\Plugin\Discount\PromotionCollectedDiscountGroupingStrategyPlugin;
 use Spryker\Zed\GiftCard\Communication\Plugin\GiftCardDiscountableItemFilterPlugin;
@@ -128,8 +129,8 @@ class DiscountDependencyProvider extends SprykerDiscountDependencyProvider
     protected function getDiscountPostUpdatePlugins(): array
     {
         return [
-            new DiscountPromotionPostUpdatePlugin(),
             new DiscountPromotionCleanerPostUpdatePlugin(),
+            new DiscountPromotionDiscountPostUpdatePlugin(),
         ];
     }
 
@@ -197,5 +198,15 @@ class DiscountDependencyProvider extends SprykerDiscountDependencyProvider
     protected function getMoneyCollectionFormTypePlugin(): FormTypeInterface
     {
         return new MoneyCollectionFormTypePlugin();
+    }
+
+    /**
+     * @return array<\Spryker\Zed\DiscountExtension\Dependency\Plugin\DiscountVoucherApplyCheckerStrategyPluginInterface>
+     */
+    protected function getDiscountVoucherApplyCheckerStrategyPlugins(): array
+    {
+        return [
+            new DiscountPromotionDiscountVoucherApplyCheckerStrategyPlugin(),
+        ];
     }
 }

--- a/src/Pyz/Zed/ErrorHandler/ErrorHandlerConfig.php
+++ b/src/Pyz/Zed/ErrorHandler/ErrorHandlerConfig.php
@@ -8,6 +8,7 @@
 namespace Pyz\Zed\ErrorHandler;
 
 use Spryker\Zed\ErrorHandler\ErrorHandlerConfig as SprykerErrorHandlerConfigAlias;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @method \Spryker\Shared\ErrorHandler\ErrorHandlerConfig getSharedConfig()

--- a/src/Pyz/Zed/ErrorHandler/ErrorHandlerConfig.php
+++ b/src/Pyz/Zed/ErrorHandler/ErrorHandlerConfig.php
@@ -8,7 +8,6 @@
 namespace Pyz\Zed\ErrorHandler;
 
 use Spryker\Zed\ErrorHandler\ErrorHandlerConfig as SprykerErrorHandlerConfigAlias;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @method \Spryker\Shared\ErrorHandler\ErrorHandlerConfig getSharedConfig()
@@ -22,11 +21,8 @@ class ErrorHandlerConfig extends SprykerErrorHandlerConfigAlias
      */
     public function getValidSubRequestExceptionStatusCodes(): array
     {
-        return array_merge(
-            parent::getValidSubRequestExceptionStatusCodes(),
-            [
-                Response::HTTP_TOO_MANY_REQUESTS,
-            ],
-        );
+        return array_merge(parent::getValidSubRequestExceptionStatusCodes(), [
+            Response::HTTP_TOO_MANY_REQUESTS,
+        ]);
     }
 }

--- a/src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php
+++ b/src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php
@@ -67,6 +67,7 @@ class EventDispatcherDependencyProvider extends SprykerEventDispatcherDependency
             new SecurityBlockerBackofficeUserEventDispatcherPlugin(),
             new SecurityBlockerMerchantPortalUserEventDispatcherPlugin(),
             new EnvironmentInfoHeaderEventDispatcherPlugin(),
+            new ProfilerRequestEventDispatcherPlugin(),
         ];
 
         if (class_exists(ProfilerRequestEventDispatcherPlugin::class)) {
@@ -111,6 +112,20 @@ class EventDispatcherDependencyProvider extends SprykerEventDispatcherDependency
             new RouterListenerEventDispatcherPlugin(),
             new ResponseListenerEventDispatcherPlugin(),
             new AutoloaderCacheEventDispatcherPlugin(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getBackofficeEventDispatcherPlugins(): array
+    {
+        return [
+            new HeadersSecurityEventDispatcherPlugin(),
+            new RouterLocaleEventDispatcherPlugin(),
+            new RouterListenerEventDispatcherPlugin(),
+            new RouterSslRedirectEventDispatcherPlugin(),
+            new RequestAttributesEventDispatcherPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Installer/InstallerDependencyProvider.php
+++ b/src/Pyz/Zed/Installer/InstallerDependencyProvider.php
@@ -17,6 +17,8 @@ use Spryker\Zed\Newsletter\Communication\Plugin\NewsletterInstallerPlugin;
 use Spryker\Zed\Oauth\Communication\Plugin\Installer\OauthClientInstallerPlugin;
 use Spryker\Zed\OauthAgentConnector\Communication\Plugin\Installer\AgentOauthScopeInstallerPlugin;
 use Spryker\Zed\OauthCustomerConnector\Communication\Plugin\Installer\OauthCustomerScopeInstallerPlugin;
+use Spryker\Zed\OauthUserConnector\Communication\Plugin\Installer\OauthUserScopeInstallerPlugin;
+use Spryker\Zed\OauthWarehouse\Communication\Plugin\Installer\OauthWarehouseInstallerPlugin;
 use Spryker\Zed\PriceProduct\Communication\Plugin\PriceInstallerPlugin;
 use Spryker\Zed\ProductAlternativeProductLabelConnector\Communication\Plugin\Installer\ProductAlternativeProductLabelConnectorInstallerPlugin;
 use Spryker\Zed\ProductDiscontinuedProductLabelConnector\Communication\Plugin\Installer\ProductDiscontinuedProductLabelConnectorInstallerPlugin;
@@ -47,6 +49,8 @@ class InstallerDependencyProvider extends SprykerInstallerDependencyProvider
             new OauthClientInstallerPlugin(),
             new OauthCustomerScopeInstallerPlugin(),
             new AgentOauthScopeInstallerPlugin(),
+            new OauthUserScopeInstallerPlugin(),
+            new OauthWarehouseInstallerPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
+++ b/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
@@ -7,9 +7,7 @@
 
 namespace Pyz\Zed\Locale;
 
-use Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface;
 use Spryker\Zed\Locale\LocaleDependencyProvider as SprykerLocaleDependencyProvider;
-use Spryker\Zed\UserLocale\Communication\Plugin\Locale\UserLocaleLocalePlugin;
 
 class LocaleDependencyProvider extends SprykerLocaleDependencyProvider
 {

--- a/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
+++ b/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
@@ -7,7 +7,9 @@
 
 namespace Pyz\Zed\Locale;
 
+use Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface;
 use Spryker\Zed\Locale\LocaleDependencyProvider as SprykerLocaleDependencyProvider;
+use Spryker\Zed\UserLocale\Communication\Plugin\Locale\UserLocaleLocalePlugin;
 
 class LocaleDependencyProvider extends SprykerLocaleDependencyProvider
 {

--- a/src/Pyz/Zed/Mail/MailDependencyProvider.php
+++ b/src/Pyz/Zed/Mail/MailDependencyProvider.php
@@ -57,6 +57,9 @@ class MailDependencyProvider extends SprykerMailDependencyProvider
                 ->addProvider(new SymfonyMailerProviderPlugin(), [
                     MailConfig::MAIL_TYPE_ALL,
                 ]);
+            $mailProviderCollection->addProvider(new SymfonyMailerProviderPlugin(), [
+                MailConfig::MAIL_TYPE_ALL,
+            ]);
 
             return $mailProviderCollection;
         });

--- a/src/Pyz/Zed/Mail/MailDependencyProvider.php
+++ b/src/Pyz/Zed/Mail/MailDependencyProvider.php
@@ -60,6 +60,9 @@ class MailDependencyProvider extends SprykerMailDependencyProvider
             $mailProviderCollection->addProvider(new SymfonyMailerProviderPlugin(), [
                 MailConfig::MAIL_TYPE_ALL,
             ]);
+            $mailProviderCollection->addProvider(new SymfonyMailerProviderPlugin(), [
+                MailConfig::MAIL_TYPE_ALL,
+            ]);
 
             return $mailProviderCollection;
         });

--- a/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
+++ b/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
@@ -12,6 +12,7 @@ use Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetDeletedMessageHand
 use Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetUpdatedMessageHandlerPlugin;
 use Spryker\Zed\Merchant\Communication\Plugin\MessageBroker\MerchantExportMerchantsMessageHandlerPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\CorrelationIdMessageAttributeProviderPlugin;
+use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TenantActorMessageAttributeProviderPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TimestampMessageAttributeProviderPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TransactionIdMessageAttributeProviderPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\ValidationMiddlewarePlugin;
@@ -31,13 +32,11 @@ use Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentPreauthorizedM
 use Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundedMessageHandlerPlugin;
 use Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundFailedMessageHandlerPlugin;
 use Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentReservationCanceledMessageHandlerPlugin;
-use Spryker\Zed\Product\Communication\Plugin\MessageBroker\InitializeProductExportMessageHandlerPlugin;
+use Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin;
 use Spryker\Zed\ProductReview\Communication\Plugin\MessageBroker\ProductReviewAddReviewsMessageHandlerPlugin;
 use Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointAvailableMessageHandlerPlugin;
 use Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointRemovedMessageHandlerPlugin;
 use Spryker\Zed\Session\Communication\Plugin\MessageBroker\SessionTrackingIdMessageAttributeProviderPlugin;
-use Spryker\Zed\Store\Communication\Plugin\MessageBroker\CurrentStoreReferenceMessageAttributeProviderPlugin;
-use Spryker\Zed\Store\Communication\Plugin\MessageBroker\StoreReferenceMessageValidatorPlugin;
 
 class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProvider
 {
@@ -82,11 +81,11 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
             new AssetAddedMessageHandlerPlugin(),
             new AssetUpdatedMessageHandlerPlugin(),
             new AssetDeletedMessageHandlerPlugin(),
-            new InitializeProductExportMessageHandlerPlugin(),
             new ProductReviewAddReviewsMessageHandlerPlugin(),
             new SearchEndpointAvailableMessageHandlerPlugin(),
             new SearchEndpointRemovedMessageHandlerPlugin(),
             new MerchantExportMerchantsMessageHandlerPlugin(),
+            new ProductExportMessageHandlerPlugin(),
         ];
     }
 
@@ -98,10 +97,10 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
         return [
             new CorrelationIdMessageAttributeProviderPlugin(),
             new TimestampMessageAttributeProviderPlugin(),
-            new CurrentStoreReferenceMessageAttributeProviderPlugin(),
             new AccessTokenMessageAttributeProviderPlugin(),
             new TransactionIdMessageAttributeProviderPlugin(),
             new SessionTrackingIdMessageAttributeProviderPlugin(),
+            new TenantActorMessageAttributeProviderPlugin(),
         ];
     }
 
@@ -112,16 +111,6 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
     {
         return [
             new ValidationMiddlewarePlugin(),
-        ];
-    }
-
-    /**
-     * @return array<\Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageValidatorPluginInterface>
-     */
-    public function getExternalValidatorPlugins(): array
-    {
-        return [
-            new StoreReferenceMessageValidatorPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Oauth/OauthDependencyProvider.php
+++ b/src/Pyz/Zed/Oauth/OauthDependencyProvider.php
@@ -17,6 +17,8 @@ use Spryker\Zed\Oauth\OauthDependencyProvider as SprykerOauthDependencyProvider;
 use Spryker\Zed\OauthAgentConnector\Communication\Plugin\Oauth\AgentCredentialsOauthGrantTypeConfigurationProviderPlugin;
 use Spryker\Zed\OauthAgentConnector\Communication\Plugin\Oauth\AgentOauthScopeProviderPlugin;
 use Spryker\Zed\OauthAgentConnector\Communication\Plugin\Oauth\AgentOauthUserProviderPlugin;
+use Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\CustomerAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin;
+use Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\UserAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin;
 use Spryker\Zed\OauthCustomerConnector\Communication\Plugin\Oauth\CustomerImpersonationOauthGrantTypeConfigurationProviderPlugin;
 use Spryker\Zed\OauthCustomerConnector\Communication\Plugin\Oauth\CustomerImpersonationOauthScopeProviderPlugin;
 use Spryker\Zed\OauthCustomerConnector\Communication\Plugin\Oauth\CustomerImpersonationOauthUserProviderPlugin;
@@ -31,6 +33,9 @@ use Spryker\Zed\OauthRevoke\Communication\Plugin\Oauth\OauthRefreshTokensReaderP
 use Spryker\Zed\OauthRevoke\Communication\Plugin\Oauth\OauthRefreshTokensRevokerPlugin;
 use Spryker\Zed\OauthUserConnector\Communication\Plugin\Oauth\UserOauthScopeProviderPlugin;
 use Spryker\Zed\OauthUserConnector\Communication\Plugin\Oauth\UserOauthUserProviderPlugin;
+use Spryker\Zed\OauthWarehouse\Communication\Plugin\Oauth\WarehouseOauthRequestGrantTypeConfigurationProviderPlugin;
+use Spryker\Zed\OauthWarehouse\Communication\Plugin\Oauth\WarehouseOauthScopeProviderPlugin;
+use Spryker\Zed\OauthWarehouse\Communication\Plugin\Oauth\WarehouseOauthUserProviderPlugin;
 
 class OauthDependencyProvider extends SprykerOauthDependencyProvider
 {
@@ -43,6 +48,7 @@ class OauthDependencyProvider extends SprykerOauthDependencyProvider
             new CustomerOauthUserProviderPlugin(),
             new AgentOauthUserProviderPlugin(),
             new CustomerImpersonationOauthUserProviderPlugin(),
+            new WarehouseOauthUserProviderPlugin(),
         ];
     }
 
@@ -66,6 +72,7 @@ class OauthDependencyProvider extends SprykerOauthDependencyProvider
             new AgentOauthScopeProviderPlugin(),
             new CustomerImpersonationOauthScopeProviderPlugin(),
             new UserOauthScopeProviderPlugin(),
+            new WarehouseOauthScopeProviderPlugin(),
         ];
     }
 
@@ -158,6 +165,9 @@ class OauthDependencyProvider extends SprykerOauthDependencyProvider
         return [
             new UserPasswordOauthRequestGrantTypeConfigurationProviderPlugin(),
             new CustomerPasswordOauthRequestGrantTypeConfigurationProviderPlugin(),
+            new UserAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin(),
+            new CustomerAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin(),
+            new WarehouseOauthRequestGrantTypeConfigurationProviderPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/OauthClient/OauthClientDependencyProvider.php
+++ b/src/Pyz/Zed/OauthClient/OauthClientDependencyProvider.php
@@ -11,7 +11,6 @@ use Spryker\Zed\OauthAuth0\Communication\Plugin\OauthClient\Auth0OauthAccessToke
 use Spryker\Zed\OauthAuth0\Communication\Plugin\OauthClient\CacheKeySeedAccessTokenRequestExpanderPlugin;
 use Spryker\Zed\OauthClient\OauthClientDependencyProvider as SprykerOauthClientDependencyProvider;
 use Spryker\Zed\OauthDummy\Communication\Plugin\OauthClient\DummyOauthAccessTokenProviderPlugin;
-use Spryker\Zed\Store\Communication\Plugin\OauthClient\CurrentStoreReferenceAccessTokenRequestExpanderPlugin;
 
 class OauthClientDependencyProvider extends SprykerOauthClientDependencyProvider
 {
@@ -32,7 +31,6 @@ class OauthClientDependencyProvider extends SprykerOauthClientDependencyProvider
     protected function getAccessTokenRequestExpanderPlugins(): array
     {
         return [
-            new CurrentStoreReferenceAccessTokenRequestExpanderPlugin(),
             new CacheKeySeedAccessTokenRequestExpanderPlugin(),
         ];
     }

--- a/src/Pyz/Zed/Oms/OmsDependencyProvider.php
+++ b/src/Pyz/Zed/Oms/OmsDependencyProvider.php
@@ -28,6 +28,9 @@ use Spryker\Zed\OmsProductOfferReservation\Communication\Plugin\Oms\ProductOffer
 use Spryker\Zed\OmsProductOfferReservation\Communication\Plugin\Oms\ProductOfferOmsReservationReaderStrategyPlugin;
 use Spryker\Zed\OmsProductOfferReservation\Communication\Plugin\Oms\ProductOfferOmsReservationWriterStrategyPlugin;
 use Spryker\Zed\OmsProductOfferReservation\Communication\Plugin\Oms\ProductOfferReservationPostSaveTerminationAwareStrategyPlugin;
+use Spryker\Zed\Payment\Communication\Plugin\Command\SendEventPaymentCancelReservationPendingPlugin as SprykerSendEventPaymentCancelReservationPendingPlugin;
+use Spryker\Zed\Payment\Communication\Plugin\Command\SendEventPaymentConfirmationPendingPlugin as SprykerSendEventPaymentConfirmationPendingPlugin;
+use Spryker\Zed\Payment\Communication\Plugin\Command\SendEventPaymentRefundPendingPlugin as SprykerSendEventPaymentRefundPendingPlugin;
 use Spryker\Zed\ProductBundle\Communication\Plugin\Oms\ProductBundleReservationPostSaveTerminationAwareStrategyPlugin;
 use Spryker\Zed\SalesInvoice\Communication\Plugin\Oms\GenerateOrderInvoiceCommandPlugin;
 use Spryker\Zed\SalesPayment\Communication\Plugin\Oms\SendEventPaymentCancelReservationPendingPlugin;
@@ -36,6 +39,7 @@ use Spryker\Zed\SalesPayment\Communication\Plugin\Oms\SendEventPaymentRefundPend
 use Spryker\Zed\SalesReturn\Communication\Plugin\Oms\Command\StartReturnCommandPlugin;
 use Spryker\Zed\Shipment\Dependency\Plugin\Oms\ShipmentManualEventGrouperPlugin;
 use Spryker\Zed\Shipment\Dependency\Plugin\Oms\ShipmentOrderMailExpanderPlugin;
+use Spryker\Zed\WarehouseAllocation\Communication\Plugin\Oms\SalesOrderWarehouseAllocationCommandPlugin;
 
 class OmsDependencyProvider extends SprykerOmsDependencyProvider
 {
@@ -106,6 +110,10 @@ class OmsDependencyProvider extends SprykerOmsDependencyProvider
             $commandCollection->add(new SendEventPaymentRefundPendingPlugin(), 'Payment/SendEventPaymentRefundPending');
             $commandCollection->add(new SendEventPaymentCancelReservationPendingPlugin(), 'Payment/SendEventPaymentCancelReservationPending');
             $commandCollection->add(new SendOrderStatusChangedMessagePlugin(), 'Order/RequestProductReviews');
+            $commandCollection->add(new SprykerSendEventPaymentConfirmationPendingPlugin(), 'Payment/SendEventPaymentConfirmationPending');
+            $commandCollection->add(new SprykerSendEventPaymentRefundPendingPlugin(), 'Payment/SendEventPaymentRefundPending');
+            $commandCollection->add(new SprykerSendEventPaymentCancelReservationPendingPlugin(), 'Payment/SendEventPaymentCancelReservationPending');
+            $commandCollection->add(new SalesOrderWarehouseAllocationCommandPlugin(), 'WarehouseAllocation/WarehouseAllocate');
 
             return $commandCollection;
         });

--- a/src/Pyz/Zed/Oms/OmsDependencyProvider.php
+++ b/src/Pyz/Zed/Oms/OmsDependencyProvider.php
@@ -114,6 +114,10 @@ class OmsDependencyProvider extends SprykerOmsDependencyProvider
             $commandCollection->add(new SprykerSendEventPaymentRefundPendingPlugin(), 'Payment/SendEventPaymentRefundPending');
             $commandCollection->add(new SprykerSendEventPaymentCancelReservationPendingPlugin(), 'Payment/SendEventPaymentCancelReservationPending');
             $commandCollection->add(new SalesOrderWarehouseAllocationCommandPlugin(), 'WarehouseAllocation/WarehouseAllocate');
+            $commandCollection->add(new SprykerSendEventPaymentConfirmationPendingPlugin(), 'Payment/SendEventPaymentConfirmationPending');
+            $commandCollection->add(new SprykerSendEventPaymentRefundPendingPlugin(), 'Payment/SendEventPaymentRefundPending');
+            $commandCollection->add(new SprykerSendEventPaymentCancelReservationPendingPlugin(), 'Payment/SendEventPaymentCancelReservationPending');
+            $commandCollection->add(new SalesOrderWarehouseAllocationCommandPlugin(), 'WarehouseAllocation/WarehouseAllocate');
 
             return $commandCollection;
         });

--- a/src/Pyz/Zed/PersistentCart/PersistentCartDependencyProvider.php
+++ b/src/Pyz/Zed/PersistentCart/PersistentCartDependencyProvider.php
@@ -8,6 +8,8 @@
 namespace Pyz\Zed\PersistentCart;
 
 use Spryker\Zed\PersistentCart\PersistentCartDependencyProvider as SprykerPersistentCartDependencyProvider;
+use Spryker\Zed\PersistentCartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
+use Spryker\Zed\ProductBundle\Communication\Plugin\PersistentCart\BundleProductQuoteItemFinderPlugin;
 use Spryker\Zed\ProductBundle\Communication\Plugin\PersistentCart\RemoveBundleChangeRequestExpanderPlugin;
 
 class PersistentCartDependencyProvider extends SprykerPersistentCartDependencyProvider

--- a/src/Pyz/Zed/PersistentCart/PersistentCartDependencyProvider.php
+++ b/src/Pyz/Zed/PersistentCart/PersistentCartDependencyProvider.php
@@ -8,8 +8,6 @@
 namespace Pyz\Zed\PersistentCart;
 
 use Spryker\Zed\PersistentCart\PersistentCartDependencyProvider as SprykerPersistentCartDependencyProvider;
-use Spryker\Zed\PersistentCartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface;
-use Spryker\Zed\ProductBundle\Communication\Plugin\PersistentCart\BundleProductQuoteItemFinderPlugin;
 use Spryker\Zed\ProductBundle\Communication\Plugin\PersistentCart\RemoveBundleChangeRequestExpanderPlugin;
 
 class PersistentCartDependencyProvider extends SprykerPersistentCartDependencyProvider
@@ -19,7 +17,7 @@ class PersistentCartDependencyProvider extends SprykerPersistentCartDependencyPr
      */
     protected function getQuoteItemFinderPlugin(): QuoteItemFinderPluginInterface
     {
-        return new BundleProductQuoteItemFinderPlugin(); #ProductBundleFeature
+        return new BundleProductQuoteItemFinderPlugin();
     }
 
     /**

--- a/src/Pyz/Zed/PriceCartConnector/PriceCartConnectorConfig.php
+++ b/src/Pyz/Zed/PriceCartConnector/PriceCartConnectorConfig.php
@@ -15,6 +15,11 @@ class PriceCartConnectorConfig extends SprykerPriceCartConnectorConfig
     /**
      * @var bool
      */
+    public const IS_ZERO_PRICE_ENABLED = false;
+
+    /**
+     * @var bool
+     */
     protected const IS_ZERO_PRICE_ENABLED_FOR_CART_ACTIONS = false;
 
     /**

--- a/src/Pyz/Zed/ProductPageSearch/ProductPageSearchDependencyProvider.php
+++ b/src/Pyz/Zed/ProductPageSearch/ProductPageSearchDependencyProvider.php
@@ -15,12 +15,14 @@ use Spryker\Shared\ProductPageSearch\ProductPageSearchConfig;
 use Spryker\Shared\ProductReviewSearch\ProductReviewSearchConfig;
 use Spryker\Zed\Availability\Communication\Plugin\ProductPageSearch\AvailabilityProductAbstractAddToCartPlugin;
 use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\ProductPageSearch\MerchantNamesProductAbstractMapExpanderPlugin;
+use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\ProductPageSearch\MerchantProductOfferProductConcretePageMapExpanderPlugin;
 use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\ProductPageSearch\MerchantProductPageDataExpanderPlugin;
 use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\ProductPageSearch\MerchantProductPageDataLoaderPlugin;
 use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\ProductPageSearch\MerchantReferencesProductAbstractsMapExpanderPlugin;
 use Spryker\Zed\MerchantProductSearch\Communication\Plugin\ProductPageSearch\MerchantProductAbstractMapExpanderPlugin;
 use Spryker\Zed\MerchantProductSearch\Communication\Plugin\ProductPageSearch\MerchantProductPageDataExpanderPlugin as MerchantMerchantProductPageDataExpanderPlugin;
 use Spryker\Zed\MerchantProductSearch\Communication\Plugin\ProductPageSearch\MerchantProductPageDataLoaderPlugin as MerchantMerchantProductPageDataLoaderPlugin;
+use Spryker\Zed\MerchantProductSearch\Communication\Plugin\ProductPageSearch\MerchantProductProductConcretePageMapExpanderPlugin;
 use Spryker\Zed\ProductApproval\Communication\Plugin\ProductPageSearch\ProductApprovalProductConcreteCollectionFilterPlugin;
 use Spryker\Zed\ProductApproval\Communication\Plugin\ProductPageSearch\ProductApprovalProductPageSearchCollectionFilterPlugin;
 use Spryker\Zed\ProductCategorySearch\Communication\Plugin\ProductPageSearch\Elasticsearch\ProductCategoryMapExpanderPlugin;
@@ -93,6 +95,8 @@ class ProductPageSearchDependencyProvider extends SprykerProductPageSearchDepend
         return [
             new ProductConcreteProductListPageMapExpanderPlugin(),
             new ProductImageProductConcretePageMapExpanderPlugin(),
+            new MerchantProductOfferProductConcretePageMapExpanderPlugin(),
+            new MerchantProductProductConcretePageMapExpanderPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
+++ b/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
@@ -242,6 +242,7 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             new ProductConcretePublisherTriggerPlugin(),
             new ShipmentTypePublisherTriggerPlugin(),
             new StorePublisherTriggerPlugin(),
+            new ProductConcretePublisherTriggerPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
+++ b/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
@@ -52,6 +52,8 @@ use Spryker\Zed\Merchant\Communication\Plugin\Publisher\MerchantUpdatedMessageBr
 use Spryker\Zed\MerchantCategory\Communication\Plugin\Publisher\Category\CategoryWritePublisherPlugin;
 use Spryker\Zed\MerchantOpeningHoursStorage\Communication\Plugin\Publisher\MerchantOpeningHours\MerchantOpeningHoursWritePublisherPlugin;
 use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\Publisher\MerchantProductOfferSearchPublisherTriggerPlugin;
+use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\Publisher\ProductOffer\ProductConcreteWritePublisherPlugin;
+use Spryker\Zed\MerchantProductOfferSearch\Communication\Plugin\Publisher\ProductOfferStore\ProductConcreteWritePublisherPlugin as SprykerProductConcreteWritePublisherPlugin;
 use Spryker\Zed\MerchantProductOfferStorage\Communication\Plugin\Publisher\Merchant\MerchantProductOfferWritePublisherPlugin;
 use Spryker\Zed\MerchantProductOfferStorage\Communication\Plugin\Publisher\ProductConcreteProductOffer\MerchantProductConcreteProductOfferWritePublisherPlugin;
 use Spryker\Zed\MerchantProductOptionStorage\Communication\Plugin\Publisher\MerchantProductOption\MerchantProductOptionGroupWritePublisherPlugin;
@@ -133,11 +135,15 @@ use Spryker\Zed\Publisher\PublisherDependencyProvider as SprykerPublisherDepende
 use Spryker\Zed\SalesReturnSearch\Communication\Plugin\Publisher\ReturnReason\ReturnReasonDeletePublisherPlugin;
 use Spryker\Zed\SalesReturnSearch\Communication\Plugin\Publisher\ReturnReason\ReturnReasonWritePublisherPlugin;
 use Spryker\Zed\SalesReturnSearch\Communication\Plugin\Publisher\ReturnReasonPublisherTriggerPlugin;
+use Spryker\Zed\ShipmentTypeStorage\Communication\Plugin\Publisher\ShipmentType\ShipmentTypeWriterPublisherPlugin;
+use Spryker\Zed\ShipmentTypeStorage\Communication\Plugin\Publisher\ShipmentTypePublisherTriggerPlugin;
+use Spryker\Zed\ShipmentTypeStorage\Communication\Plugin\Publisher\ShipmentTypeStore\ShipmentTypeStoreWriterPublisherPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\CountryStore\CountryStoreWritePublisherPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\CurrencyStore\CurrencyStoreWritePublisherPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\LocaleStore\LocaleStoreWritePublisherPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\Store\StoreSynchronizationTriggeringPublisherPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\Store\StoreWritePublisherPlugin;
+use Spryker\Zed\StoreStorage\Communication\Plugin\Publisher\StorePublisherTriggerPlugin;
 use Spryker\Zed\TaxProductStorage\Communication\Plugin\Publisher\TaxProductPublisherTriggerPlugin;
 use Spryker\Zed\TaxStorage\Communication\Plugin\Publisher\TaxSetPublisherTriggerPlugin;
 
@@ -178,6 +184,7 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             $this->getProductConfigurationStoragePlugins(),
             $this->getProductOfferAvailabilityStoragePlugins(),
             $this->getMerchantExportPlugins(),
+            $this->getShipmentTypeStoragePlugins(),
         );
     }
 
@@ -232,6 +239,9 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             new AssetPublisherTriggerPlugin(),
             new PriceProductOfferPublisherTriggerPlugin(),
             new CustomerAccessPublisherTriggerPlugin(),
+            new ProductConcretePublisherTriggerPlugin(),
+            new ShipmentTypePublisherTriggerPlugin(),
+            new StorePublisherTriggerPlugin(),
         ];
     }
 
@@ -573,6 +583,28 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             new MerchantExportedMessageBrokerPublisherPlugin(),
             new MerchantCreatedMessageBrokerPublisherPlugin(),
             new MerchantUpdatedMessageBrokerPublisherPlugin(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getMerchantProductOfferSearchPlugins(): array
+    {
+        return [
+            new ProductConcreteWritePublisherPlugin(),
+            new SprykerProductConcreteWritePublisherPlugin(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getShipmentTypeStoragePlugins(): array
+    {
+        return [
+            new ShipmentTypeWriterPublisherPlugin(),
+            new ShipmentTypeStoreWriterPublisherPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Queue/QueueDependencyProvider.php
+++ b/src/Pyz/Zed/Queue/QueueDependencyProvider.php
@@ -44,6 +44,7 @@ use Spryker\Shared\PublishAndSynchronizeHealthCheckStorage\PublishAndSynchronize
 use Spryker\Shared\Publisher\PublisherConfig;
 use Spryker\Shared\SalesReturnSearch\SalesReturnSearchConfig;
 use Spryker\Shared\SearchHttp\SearchHttpConfig;
+use Spryker\Shared\ShipmentTypeStorage\ShipmentTypeStorageConfig;
 use Spryker\Shared\StoreStorage\StoreStorageConfig;
 use Spryker\Shared\TaxProductStorage\TaxProductStorageConfig;
 use Spryker\Shared\TaxStorage\TaxStorageConfig;
@@ -116,6 +117,7 @@ class QueueDependencyProvider extends SprykerDependencyProvider
             AssetStorageConfig::ASSET_SYNC_STORAGE_QUEUE => new SynchronizationStorageQueueMessageProcessorPlugin(),
             ProductConfigurationStorageConfig::PRODUCT_CONFIGURATION_SYNC_STORAGE_QUEUE => new SynchronizationStorageQueueMessageProcessorPlugin(),
             SearchHttpConfig::SEARCH_HTTP_CONFIG_SYNC_QUEUE => new SynchronizationStorageQueueMessageProcessorPlugin(),
+            ShipmentTypeStorageConfig::QUEUE_NAME_SYNC_STORAGE_SHIPMENT_TYPE => new SynchronizationStorageQueueMessageProcessorPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Router/RouterDependencyProvider.php
+++ b/src/Pyz/Zed/Router/RouterDependencyProvider.php
@@ -11,6 +11,8 @@ use Spryker\Zed\Router\Communication\Plugin\Router\BackendGatewayRouterPlugin;
 use Spryker\Zed\Router\Communication\Plugin\Router\BackofficeRouterPlugin;
 use Spryker\Zed\Router\Communication\Plugin\Router\MerchantPortalRouterPlugin;
 use Spryker\Zed\Router\Communication\Plugin\Router\RouterEnhancer\BackwardsCompatibleUrlRouterEnhancerPlugin;
+use Spryker\Zed\Router\Communication\Plugin\Router\ZedDevelopmentRouterPlugin;
+use Spryker\Zed\Router\Communication\Plugin\Router\ZedRouterPlugin;
 use Spryker\Zed\Router\RouterDependencyProvider as SprykerRouterDependencyProvider;
 
 class RouterDependencyProvider extends SprykerRouterDependencyProvider
@@ -60,6 +62,17 @@ class RouterDependencyProvider extends SprykerRouterDependencyProvider
     {
         return [
             new BackwardsCompatibleUrlRouterEnhancerPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Zed\RouterExtension\Dependency\Plugin\RouterPluginInterface>
+     */
+    protected function getRouterPlugins(): array
+    {
+        return [
+            new ZedRouterPlugin(),
+            new ZedDevelopmentRouterPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Sales/SalesDependencyProvider.php
+++ b/src/Pyz/Zed/Sales/SalesDependencyProvider.php
@@ -52,6 +52,7 @@ use Spryker\Zed\SalesReturn\Communication\Plugin\Sales\RemunerationTotalOrderExp
 use Spryker\Zed\SalesReturn\Communication\Plugin\Sales\UpdateOrderItemIsReturnableByGlobalReturnableNumberOfDaysPlugin;
 use Spryker\Zed\SalesReturn\Communication\Plugin\Sales\UpdateOrderItemIsReturnableByItemStatePlugin;
 use Spryker\Zed\Shipment\Communication\Plugin\ShipmentOrderHydratePlugin;
+use Spryker\Zed\WarehouseAllocation\Communication\Plugin\Sales\WarehouseOrderItemExpanderPlugin;
 
 class SalesDependencyProvider extends SprykerSalesDependencyProvider
 {
@@ -170,6 +171,7 @@ class SalesDependencyProvider extends SprykerSalesDependencyProvider
             new ProductBundleOptionItemExpanderPlugin(),
             new ItemStateOrderItemExpanderPlugin(),
             new ProductConfigurationOrderItemExpanderPlugin(),
+            new WarehouseOrderItemExpanderPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/SalesPayment/SalesPaymentDependencyProvider.php
+++ b/src/Pyz/Zed/SalesPayment/SalesPaymentDependencyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\SalesPayment;
+
+use Spryker\Zed\GiftCard\Communication\Plugin\SalesPayment\GiftCardPaymentMapKeyBuilderStrategyPlugin;
+use Spryker\Zed\SalesPayment\SalesPaymentDependencyProvider as SprykerSalesPaymentDependencyProvider;
+
+class SalesPaymentDependencyProvider extends SprykerSalesPaymentDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Zed\SalesPaymentExtension\Dependency\Plugin\PaymentMapKeyBuilderStrategyPluginInterface>
+     */
+    protected function getPaymentMapKeyBuilderStrategyPlugins(): array
+    {
+        return [
+            new GiftCardPaymentMapKeyBuilderStrategyPlugin(),
+        ];
+    }
+}

--- a/src/Pyz/Zed/SessionUserValidation/SessionUserValidationDependencyProvider.php
+++ b/src/Pyz/Zed/SessionUserValidation/SessionUserValidationDependencyProvider.php
@@ -7,11 +7,7 @@
 
 namespace Pyz\Zed\SessionUserValidation;
 
-use Spryker\Zed\SessionRedis\Communication\Plugin\SessionUserValidation\SessionRedisSessionUserSaverPlugin;
-use Spryker\Zed\SessionRedis\Communication\Plugin\SessionUserValidation\SessionRedisSessionUserValidatorPlugin;
 use Spryker\Zed\SessionUserValidation\SessionUserValidationDependencyProvider as SprykerSessionUserValidationDependencyProvider;
-use Spryker\Zed\SessionUserValidationExtension\Dependency\Plugin\SessionUserSaverPluginInterface;
-use Spryker\Zed\SessionUserValidationExtension\Dependency\Plugin\SessionUserValidatorPluginInterface;
 
 class SessionUserValidationDependencyProvider extends SprykerSessionUserValidationDependencyProvider
 {

--- a/src/Pyz/Zed/SessionUserValidation/SessionUserValidationDependencyProvider.php
+++ b/src/Pyz/Zed/SessionUserValidation/SessionUserValidationDependencyProvider.php
@@ -7,7 +7,11 @@
 
 namespace Pyz\Zed\SessionUserValidation;
 
+use Spryker\Zed\SessionRedis\Communication\Plugin\SessionUserValidation\SessionRedisSessionUserSaverPlugin;
+use Spryker\Zed\SessionRedis\Communication\Plugin\SessionUserValidation\SessionRedisSessionUserValidatorPlugin;
 use Spryker\Zed\SessionUserValidation\SessionUserValidationDependencyProvider as SprykerSessionUserValidationDependencyProvider;
+use Spryker\Zed\SessionUserValidationExtension\Dependency\Plugin\SessionUserSaverPluginInterface;
+use Spryker\Zed\SessionUserValidationExtension\Dependency\Plugin\SessionUserValidatorPluginInterface;
 
 class SessionUserValidationDependencyProvider extends SprykerSessionUserValidationDependencyProvider
 {

--- a/src/Pyz/Zed/Shipment/ShipmentConfig.php
+++ b/src/Pyz/Zed/Shipment/ShipmentConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\Shipment;
+
+use Spryker\Zed\Shipment\ShipmentConfig as SprykerShipmentConfig;
+
+class ShipmentConfig extends SprykerShipmentConfig
+{
+    /**
+     * Specification:
+     * - If set to `true` a stack of {@link \Spryker\Zed\CalculationExtension\Dependency\Plugin\QuotePostRecalculatePluginStrategyInterface} will be executed after quote recalculation.
+     * - Impacts {@link \Spryker\Zed\Shipment\Business\ShipmentFacade::expandQuoteWithShipmentGroups()} method.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function shouldExecuteQuotePostRecalculationPlugins(): bool
+    {
+        return false;
+    }
+}

--- a/src/Pyz/Zed/ShipmentTypeStorage/ShipmentTypeStorageConfig.php
+++ b/src/Pyz/Zed/ShipmentTypeStorage/ShipmentTypeStorageConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\ShipmentTypeStorage;
+
+use Pyz\Zed\Synchronization\SynchronizationConfig;
+use Spryker\Zed\ShipmentTypeStorage\ShipmentTypeStorageConfig as SprykerShipmentTypeStorageConfig;
+
+class ShipmentTypeStorageConfig extends SprykerShipmentTypeStorageConfig
+{
+    /**
+     * @api
+     *
+     * @return string|null
+     */
+    public function getShipmentTypeStorageSynchronizationPoolName(): ?string
+    {
+        return SynchronizationConfig::PYZ_DEFAULT_SYNCHRONIZATION_POOL_NAME;
+    }
+}

--- a/src/Pyz/Zed/ShipmentTypeStorage/ShipmentTypeStorageConfig.php
+++ b/src/Pyz/Zed/ShipmentTypeStorage/ShipmentTypeStorageConfig.php
@@ -7,7 +7,6 @@
 
 namespace Pyz\Zed\ShipmentTypeStorage;
 
-use Pyz\Zed\Synchronization\SynchronizationConfig;
 use Spryker\Zed\ShipmentTypeStorage\ShipmentTypeStorageConfig as SprykerShipmentTypeStorageConfig;
 
 class ShipmentTypeStorageConfig extends SprykerShipmentTypeStorageConfig

--- a/src/Pyz/Zed/StoreStorage/StoreStorageConfig.php
+++ b/src/Pyz/Zed/StoreStorage/StoreStorageConfig.php
@@ -7,6 +7,7 @@
 
 namespace Pyz\Zed\StoreStorage;
 
+use Pyz\Zed\Synchronization\SynchronizationConfig;
 use Spryker\Shared\CompanyUserStorage\CompanyUserStorageConfig;
 use Spryker\Shared\CustomerAccessStorage\CustomerAccessStorageConstants;
 use Spryker\Shared\GlossaryStorage\GlossaryStorageConfig;

--- a/src/Pyz/Zed/StoreStorage/StoreStorageConfig.php
+++ b/src/Pyz/Zed/StoreStorage/StoreStorageConfig.php
@@ -7,12 +7,14 @@
 
 namespace Pyz\Zed\StoreStorage;
 
-use Pyz\Zed\Synchronization\SynchronizationConfig;
+use Spryker\Shared\CompanyUserStorage\CompanyUserStorageConfig;
 use Spryker\Shared\CustomerAccessStorage\CustomerAccessStorageConstants;
 use Spryker\Shared\GlossaryStorage\GlossaryStorageConfig;
 use Spryker\Shared\MerchantSearch\MerchantSearchConfig;
 use Spryker\Shared\MerchantStorage\MerchantStorageConfig;
 use Spryker\Shared\NavigationStorage\NavigationStorageConstants;
+use Spryker\Shared\ProductMeasurementUnitStorage\ProductMeasurementUnitStorageConfig;
+use Spryker\Shared\ProductPackagingUnitStorage\ProductPackagingUnitStorageConfig;
 use Spryker\Shared\ProductReviewSearch\ProductReviewSearchConfig;
 use Spryker\Shared\SalesReturnSearch\SalesReturnSearchConfig;
 use Spryker\Zed\StoreStorage\StoreStorageConfig as SprykerStoreStorageConfig;
@@ -40,6 +42,9 @@ class StoreStorageConfig extends SprykerStoreStorageConfig
             MerchantStorageConfig::MERCHANT_RESOURCE_NAME,
             SalesReturnSearchConfig::RETURN_REASON_RESOURCE_NAME,
             MerchantSearchConfig::MERCHANT_RESOURCE_NAME,
+            ProductMeasurementUnitStorageConfig::PRODUCT_MEASUREMENT_UNIT_RESOURCE_NAME,
+            ProductPackagingUnitStorageConfig::PRODUCT_PACKAGING_UNIT_RESOURCE_NAME,
+            CompanyUserStorageConfig::COMPANY_USER_RESOURCE_NAME,
         ];
     }
 }

--- a/src/Pyz/Zed/Synchronization/SynchronizationDependencyProvider.php
+++ b/src/Pyz/Zed/Synchronization/SynchronizationDependencyProvider.php
@@ -66,6 +66,7 @@ use Spryker\Zed\ProductStorage\Communication\Plugin\Synchronization\ProductAbstr
 use Spryker\Zed\ProductStorage\Communication\Plugin\Synchronization\ProductConcreteSynchronizationDataPlugin;
 use Spryker\Zed\SalesReturnSearch\Communication\Plugin\Synchronization\ReturnReasonSynchronizationDataBulkRepositoryPlugin;
 use Spryker\Zed\SearchHttp\Communication\Plugin\Synchronization\SearchHttpSynchronizationDataPlugin;
+use Spryker\Zed\ShipmentTypeStorage\Communication\Plugin\Synchronization\ShipmentTypeSynchronizationDataBulkRepositoryPlugin;
 use Spryker\Zed\StoreStorage\Communication\Plugin\Synchronization\StoreSynchronizationDataPlugin;
 use Spryker\Zed\Synchronization\Communication\Plugin\Synchronization\SynchronizationDataQueryExpanderWhereBetweenStrategyPlugin;
 use Spryker\Zed\Synchronization\SynchronizationDependencyProvider as SprykerSynchronizationDependencyProvider;
@@ -148,6 +149,7 @@ class SynchronizationDependencyProvider extends SprykerSynchronizationDependency
             new AssetStorageSynchronizationDataPlugin(),
             new ProductConfigurationSynchronizationDataRepositoryPlugin(),
             new SearchHttpSynchronizationDataPlugin(),
+            new ShipmentTypeSynchronizationDataBulkRepositoryPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/User/UserConfig.php
+++ b/src/Pyz/Zed/User/UserConfig.php
@@ -124,6 +124,63 @@ class UserConfig extends SprykerUserConfig
                 'isAgent' => 1,
                 'localeName' => 'en_US',
             ],
+            [
+                'firstName' => 'Admin',
+                'lastName' => 'Spryker',
+                'username' => 'admin@spryker.com',
+                'password' => 'change123',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Admin',
+                'lastName' => 'German',
+                'password' => 'change123',
+                'username' => 'admin_de@spryker.com',
+                'localeName' => 'de_DE',
+            ],
+            [
+                'firstName' => 'Harald',
+                'lastName' => 'Schmidt',
+                'password' => 'change123',
+                'username' => 'harald@spryker.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Richard',
+                'lastName' => 'Gere',
+                'password' => 'change123',
+                'username' => 'richard@spryker.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Martha',
+                'lastName' => 'Farmer',
+                'password' => 'change123',
+                'username' => 'martha@video-king.nl',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Jason',
+                'lastName' => 'Weidmann',
+                'password' => 'change123',
+                'username' => 'jason.weidmann@budgetcamerasonline.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Michele',
+                'lastName' => 'Nemeth',
+                'password' => 'change123',
+                'username' => 'michele@sony-experts.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Vitaliy',
+                'lastName' => 'Smith',
+                'password' => 'change123',
+                'username' => 'agent123@spryker.com',
+                'isAgent' => 1,
+                'localeName' => 'en_US',
+            ],
         ];
     }
 }

--- a/src/Pyz/Zed/User/UserConfig.php
+++ b/src/Pyz/Zed/User/UserConfig.php
@@ -12,6 +12,11 @@ use Spryker\Zed\User\UserConfig as SprykerUserConfig;
 class UserConfig extends SprykerUserConfig
 {
     /**
+     * @var bool
+     */
+    protected const IS_POST_SAVE_PLUGINS_ENABLED_AFTER_USER_STATUS_CHANGE = true;
+
+    /**
      * @return array<array<string, mixed>>
      */
     public function getInstallerUsers(): array
@@ -61,6 +66,63 @@ class UserConfig extends SprykerUserConfig
                 'lastName' => 'Nemeth',
                 'password' => 'change123',
                 'username' => 'michele@sony-experts.com',
+            ],
+            [
+                'firstName' => 'Admin',
+                'lastName' => 'Spryker',
+                'username' => 'admin@spryker.com',
+                'password' => 'change123',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Admin',
+                'lastName' => 'German',
+                'password' => 'change123',
+                'username' => 'admin_de@spryker.com',
+                'localeName' => 'de_DE',
+            ],
+            [
+                'firstName' => 'Harald',
+                'lastName' => 'Schmidt',
+                'password' => 'change123',
+                'username' => 'harald@spryker.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Richard',
+                'lastName' => 'Gere',
+                'password' => 'change123',
+                'username' => 'richard@spryker.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Martha',
+                'lastName' => 'Farmer',
+                'password' => 'change123',
+                'username' => 'martha@video-king.nl',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Jason',
+                'lastName' => 'Weidmann',
+                'password' => 'change123',
+                'username' => 'jason.weidmann@budgetcamerasonline.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Michele',
+                'lastName' => 'Nemeth',
+                'password' => 'change123',
+                'username' => 'michele@sony-experts.com',
+                'localeName' => 'en_US',
+            ],
+            [
+                'firstName' => 'Vitaliy',
+                'lastName' => 'Smith',
+                'password' => 'change123',
+                'username' => 'agent123@spryker.com',
+                'isAgent' => 1,
+                'localeName' => 'en_US',
             ],
         ];
     }

--- a/src/Pyz/Zed/User/UserDependencyProvider.php
+++ b/src/Pyz/Zed/User/UserDependencyProvider.php
@@ -15,7 +15,7 @@ use Spryker\Zed\CustomerUserConnectorGui\Communication\Plugin\UserTableActionExp
 use Spryker\Zed\Kernel\Container;
 use Spryker\Zed\User\UserDependencyProvider as SprykerUserDependencyProvider;
 use Spryker\Zed\UserLocale\Communication\Plugin\User\AssignUserLocalePreSavePlugin;
-use Spryker\Zed\UserLocale\Communication\Plugin\User\UserLocaleTransferExpanderPlugin;
+use Spryker\Zed\UserLocale\Communication\Plugin\User\LocaleUserExpanderPlugin;
 use Spryker\Zed\UserLocaleGui\Communication\Plugin\UserLocaleFormExpanderPlugin;
 
 class UserDependencyProvider extends SprykerUserDependencyProvider
@@ -86,12 +86,12 @@ class UserDependencyProvider extends SprykerUserDependencyProvider
     }
 
     /**
-     * @return array<\Spryker\Zed\UserExtension\Dependency\Plugin\UserTransferExpanderPluginInterface>
+     * @return array<\Spryker\Zed\UserExtension\Dependency\Plugin\UserExpanderPluginInterface>
      */
-    protected function getUserTransferExpanderPlugins(): array
+    protected function getUserExpanderPlugins(): array
     {
         return [
-            new UserLocaleTransferExpanderPlugin(),
+            new LocaleUserExpanderPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/WebProfiler/WebProfilerDependencyProvider.php
+++ b/src/Pyz/Zed/WebProfiler/WebProfilerDependencyProvider.php
@@ -40,6 +40,7 @@ class WebProfilerDependencyProvider extends SprykerWebProfilerDependencyProvider
             new WebProfilerMemoryDataCollectorPlugin(),
             new WebProfilerTimeDataCollectorPlugin(),
             new WebProfilerTwigDataCollectorPlugin(),
+            new WebProfilerProfilerDataCollectorPlugin(),
         ];
 
         if (class_exists(WebProfilerProfilerDataCollectorPlugin::class)) {

--- a/src/Pyz/Zed/Wishlist/WishlistDependencyProvider.php
+++ b/src/Pyz/Zed/Wishlist/WishlistDependencyProvider.php
@@ -12,7 +12,9 @@ use Spryker\Zed\Availability\Communication\Plugin\Wishlist\SellableWishlistItemE
 use Spryker\Zed\MerchantProductOfferWishlist\Communication\Plugin\Wishlist\ValidMerchantProductOfferAddItemPreCheckPlugin;
 use Spryker\Zed\MerchantProductOfferWishlist\Communication\Plugin\Wishlist\ValidMerchantProductOfferUpdateItemPreCheckPlugin;
 use Spryker\Zed\MerchantProductOfferWishlist\Communication\Plugin\Wishlist\WishlistProductOfferPreAddItemPlugin;
+use Spryker\Zed\MerchantProductOfferWishlist\Communication\Plugin\Wishlist\WishlistProductOfferPreUpdateItemPlugin;
 use Spryker\Zed\MerchantProductWishlist\Communication\Plugin\Wishlist\WishlistMerchantProductPreAddItemPlugin;
+use Spryker\Zed\MerchantProductWishlist\Communication\Plugin\Wishlist\WishlistMerchantProductPreUpdateItemPlugin;
 use Spryker\Zed\PriceProduct\Communication\Plugin\Wishlist\PriceProductWishlistItemExpanderPlugin;
 use Spryker\Zed\PriceProductOffer\Communication\Plugin\Wishlist\PriceProductOfferWishlistItemExpanderPlugin;
 use Spryker\Zed\ProductConfigurationWishlist\Communication\Plugin\Wishlist\ProductConfigurationItemExpanderPlugin;
@@ -94,6 +96,8 @@ class WishlistDependencyProvider extends SprykerWishlistDependencyProvider
     {
         return [
             new ProductConfigurationWishlistPreUpdateItemPlugin(),
+            new WishlistProductOfferPreUpdateItemPlugin(),
+            new WishlistMerchantProductPreUpdateItemPlugin(),
         ];
     }
 


### PR DESCRIPTION
Upgrader installed 2 release group(s) (including 2 security fix(es)) containing 59 package version(s).
| Release | Efforts saved by Upgrader | Warnings detected? |
| ------- | ---- | ------------------ |
| [Updated `npm` dependencies.](https://api.release.spryker.com/release-group/5004) |0% |Yes :warning: |
| [Update npm dependency.](https://api.release.spryker.com/release-group/5089) |0% |Yes :warning: |

There are also [releases](https://api.release.spryker.com/release-history?sort=released&direction=asc&project_only=1&released_from%5Bday%5D=09&released_from%5Bmonth%5D=10&released_from%5Byear%5D=2023), that did not include any modules, please check them out.

## Warnings
> [!IMPORTANT] 
> <b>Composer issues.</b> Problem 1
    - spryker-shop/customer-page 2.49.0 requires php >=8.1 -> your php version (8.0.9; overridden via config.platform, actual: 8.1.22) does not satisfy that requirement.
    - spryker-feature/customer-account-management 202307.0 requires spryker-shop/customer-page ^2.43.0 -> satisfiable by spryker-shop/customer-page[2.49.0].
    - spryker-feature/customer-account-management is locked to version 202307.0 and an update of this package was not requested.


<details><summary><h4>PHP classes that became not compatible with Spryker Release</h4></summary>Switch to this branch, bootstrap your project in the development environment, open the mentioned file, and compare its correctness to the released version by Spryker.

| Composer command | Project file(s) | 
|------------------|-----------------|
'composer' 'update' 'spryker/chart:1.5.0' '--no-scripts' '--no-plugins' '--no-interaction' '-W' | <b>src/Pyz/Service/Shipment/ShipmentConfig.php</b><br>Access to undefined constant Generated\Shared\Transfer\ShipmentTransfer::SHIPMENT_TYPE_UUID.<br><br><b>src/Pyz/Zed/Category/CategoryDependencyProvider.php</b><br>Method Pyz\Zed\Category\CategoryDependencyProvider::getCategoryStoreAssignerPlugin() has invalid return type Pyz\Zed\Category\CategoryStoreAssignerPluginInterface.<br><br><b>src/Pyz/Zed/Category/CategoryDependencyProvider.php</b><br>PHPDoc tag @return with type Spryker\Zed\CategoryExtension\Dependency\Plugin\CategoryStoreAssignerPluginInterface is not subtype of native type Pyz\Zed\Category\CategoryStoreAssignerPluginInterface.<br><br><b>src/Pyz/Zed/Category/CategoryDependencyProvider.php</b><br>Return type Pyz\Zed\Category\CategoryStoreAssignerPluginInterface of method Pyz\Zed\Category\CategoryDependencyProvider::getCategoryStoreAssignerPlugin() is not covariant with return type Spryker\Zed\CategoryExtension\Dependency\Plugin\CategoryStoreAssignerPluginInterface of method Spryker\Zed\Category\CategoryDependencyProvider::getCategoryStoreAssignerPlugin().<br><br><b>src/Pyz/Zed/Category/CategoryDependencyProvider.php</b><br>Instantiated class Pyz\Zed\Category\MainChildrenPropagationCategoryStoreAssignerPlugin not found.<br><br><b>src/Pyz/Zed/Category/CategoryDependencyProvider.php</b><br>Method Pyz\Zed\Category\CategoryDependencyProvider::getCategoryStoreAssignerPlugin() should return Pyz\Zed\Category\CategoryStoreAssignerPluginInterface but returns Pyz\Zed\Category\MainChildrenPropagationCategoryStoreAssignerPlugin.<br><br><b>src/Pyz/Zed/ErrorHandler/ErrorHandlerConfig.php</b><br>Access to constant HTTP_TOO_MANY_REQUESTS on an unknown class Pyz\Zed\ErrorHandler\Response.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() has invalid return type Pyz\Zed\Locale\LocalePluginInterface.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>PHPDoc tag @return with type Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface is not subtype of native type Pyz\Zed\Locale\LocalePluginInterface.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Return type Pyz\Zed\Locale\LocalePluginInterface of method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() is not covariant with return type Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface of method Spryker\Zed\Locale\LocaleDependencyProvider::getLocalePlugin().<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Instantiated class Pyz\Zed\Locale\UserLocaleLocalePlugin not found.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() should return Pyz\Zed\Locale\LocalePluginInterface but returns Pyz\Zed\Locale\UserLocaleLocalePlugin.<br> | 
- | <b>src/Pyz/Client/Cart/CartDependencyProvider.php</b><br>PHPDoc tag @return with type Spryker\Client\Cart\Dependency\Plugin\ItemCountPluginInterface is not subtype of native type Spryker\Client\ProductBundle\Plugin\Cart\ProductBundleItemCountQuantityPlugin.<br><br><b>src/Pyz/Client/Cart/CartDependencyProvider.php</b><br>PHPDoc tag @return with type Spryker\Client\CartExtension\Dependency\Plugin\QuoteItemFinderPluginInterface is not subtype of native type Spryker\Client\ProductBundle\Plugin\Cart\BundleProductQuoteItemFinderPlugin.<br><br><b>src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php</b><br>Instantiated class Spryker\Glue\GlueBackendApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorOpenApi\AuthorizationContextExpanderPlugin not found.<br><br><b>src/Pyz/Glue/DocumentationGeneratorApi/DocumentationGeneratorApiDependencyProvider.php</b><br>Instantiated class Spryker\Glue\GlueStorefrontApiApplicationAuthorizationConnector\Plugin\DocumentationGeneratorOpenApi\AuthorizationContextExpanderPlugin not found.<br><br><b>src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php</b><br>Method Pyz\Glue\GlueBackendApiApplication\GlueBackendApiApplicationDependencyProvider::getRequestValidatorPlugins() should return array<Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\RequestValidatorPluginInterface> but returns array<int, Spryker\Glue\OauthBackendApi\Plugin\AccessTokenValidatorPlugin\|Spryker\Glue\OauthBackendApi\Plugin\GlueApplication\UserRequestValidatorPlugin\|Spryker\Glue\OauthBackendApi\Plugin\UserRequestValidatorPlugin>.<br><br><b>src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php</b><br>Instantiated class Spryker\Glue\OauthBackendApi\Plugin\UserRequestValidatorPlugin not found.<br><br><b>src/Pyz/Glue/GlueJsonApiConvention/GlueJsonApiConventionDependencyProvider.php</b><br>Method Pyz\Glue\GlueJsonApiConvention\GlueJsonApiConventionDependencyProvider::getRequestBuilderPlugins() should return array<Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\RequestBuilderPluginInterface> but returns array<int, Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\AttributesRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\ConventionIdentifierRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\FilterFieldRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\PaginationRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\RelationshipRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\SortRequestBuilderPlugin\|Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\SparseFieldRequestBuilderPlugin>.<br><br><b>src/Pyz/Glue/GlueJsonApiConvention/GlueJsonApiConventionDependencyProvider.php</b><br>Instantiated class Spryker\Glue\GlueJsonApiConvention\Plugin\GlueApplication\ConventionIdentifierRequestBuilderPlugin not found.<br><br><b>src/Pyz/Glue/GlueStorefrontApiApplication/GlueStorefrontApiApplicationDependencyProvider.php</b><br>Method Pyz\Glue\GlueStorefrontApiApplication\GlueStorefrontApiApplicationDependencyProvider::getRequestValidatorPlugins() should return array<Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\RequestValidatorPluginInterface> but returns array<int, Spryker\Glue\OauthApi\Plugin\AccessTokenValidatorPlugin\|Spryker\Glue\OauthApi\Plugin\CustomerRequestValidatorPlugin\|Spryker\Glue\OauthApi\Plugin\GlueApplication\CustomerRequestValidatorPlugin>.<br><br><b>src/Pyz/Glue/GlueStorefrontApiApplication/GlueStorefrontApiApplicationDependencyProvider.php</b><br>Instantiated class Spryker\Glue\OauthApi\Plugin\CustomerRequestValidatorPlugin not found.<br><br><b>src/Pyz/Shared/GlueBackendApiApplicationAuthorizationConnector/GlueBackendApiApplicationAuthorizationConnectorConfig.php</b><br>Array has 2 duplicate keys with value '/warehouse-tokens' ('/warehouse-tokens', '/warehouse-tokens').<br><br><b>src/Pyz/Yves/CheckoutPage/CheckoutPageDependencyProvider.php</b><br>Class SprykerShop\Yves\CheckoutPage\Plugin\StepEngine\PaymentForeignHandlerPlugin does not have a constructor and must be instantiated without any parameters.<br><br><b>src/Pyz/Yves/ShopApplication/ShopApplicationDependencyProvider.php</b><br>Method Pyz\Yves\ShopApplication\ShopApplicationDependencyProvider::getGlobalWidgets() should return array<class-string<Spryker\Yves\Kernel\Widget\AbstractWidget>> but returns array<int, SprykerShop\Yves\StoreWidget\Widget\StoreSwitcherWidget\|string>.<br><br><b>src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php</b><br>Instantiated class Pyz\Zed\CartsRestApi\SprykerQuoteCreatorPlugin not found.<br><br><b>src/Pyz/Zed/CartsRestApi/CartsRestApiDependencyProvider.php</b><br>Method Pyz\Zed\CartsRestApi\CartsRestApiDependencyProvider::getQuoteCreatorPlugin() should return Spryker\Zed\CartsRestApiExtension\Dependency\Plugin\QuoteCreatorPluginInterface but returns Pyz\Zed\CartsRestApi\SprykerQuoteCreatorPlugin.<br><br><b>src/Pyz/Zed/Checkout/CheckoutDependencyProvider.php</b><br>Method Pyz\Zed\Checkout\CheckoutDependencyProvider::getCheckoutOrderSavers() should return array<Spryker\Zed\Checkout\Dependency\Plugin\CheckoutSaveOrderInterface\|Spryker\Zed\CheckoutExtension\Dependency\Plugin\CheckoutDoSaveOrderInterface> but returns array<int, Spryker\Zed\CartNote\Communication\Plugin\Checkout\CartNoteSaverPlugin\|Spryker\Zed\Customer\Communication\Plugin\Checkout\CustomerOrderSavePlugin\|Spryker\Zed\Discount\Communication\Plugin\Checkout\DiscountOrderSavePlugin\|Spryker\Zed\GiftCard\Communication\Plugin\Checkout\GiftCardCheckoutDoSaveOrderPlugin\|Spryker\Zed\ProductBundle\Communication\Plugin\Checkout\ProductBundleOrderSaverPlugin\|Spryker\Zed\ProductOption\Communication\Plugin\Checkout\ProductOptionOrderSaverPlugin\|Spryker\Zed\Sales\Communication\Plugin\Checkout\OrderItemsSaverPlugin\|Spryker\Zed\Sales\Communication\Plugin\Checkout\OrderSaverPlugin\|Spryker\Zed\Sales\Communication\Plugin\Checkout\OrderTotalsSaverPlugin\|Spryker\Zed\SalesOrderThreshold\Communication\Plugin\Checkout\SalesOrderThresholdExpenseSavePlugin\|Spryker\Zed\SalesPayment\Communication\Plugin\Checkout\SalesPaymentCheckoutDoSaveOrderPlugin\|Spryker\Zed\SalesProductConfiguration\Communication\Plugin\Checkout\ProductConfigurationOrderSaverPlugin\|Spryker\Zed\Shipment\Communication\Plugin\Checkout\SalesOrderShipmentSavePlugin>.<br><br><b>src/Pyz/Zed/Checkout/CheckoutDependencyProvider.php</b><br>Instantiated class Spryker\Zed\SalesProductConfiguration\Communication\Plugin\Checkout\ProductConfigurationOrderSaverPlugin not found.<br><br><b>src/Pyz/Zed/Console/ConsoleDependencyProvider.php</b><br>Access to undefined constant static(Pyz\Zed\Console\ConsoleDependencyProvider)::COMMAND_SEPARATOR.<br><br><b>src/Pyz/Zed/Console/ConsoleDependencyProvider.php</b><br>Call to an undefined method Pyz\Zed\Console\ConsoleConfig::isDevelopmentConsoleCommandsEnabled().<br><br><b>src/Pyz/Zed/DataImport/Business/Model/Product/Repository/ProductRepository.php</b><br>Call to an undefined method Propel\Runtime\Collection\Collection::toArray().<br><br><b>src/Pyz/Zed/DataImport/Business/Model/ProductStock/Writer/ProductStockPropelDataSetWriter.php</b><br>Call to an undefined method Propel\Runtime\Collection\Collection::toArray().<br><br><b>src/Pyz/Zed/ExampleStateMachine/Persistence/ExampleStateMachineQueryContainer.php</b><br>Method Pyz\Zed\ExampleStateMachine\Persistence\ExampleStateMachineQueryContainer::queryPyzAllStateMachineItems() should return iterable<Orm\Zed\ExampleStateMachine\Persistence\PyzExampleStateMachineItem>&Propel\Runtime\Collection\ObjectCollection but returns Propel\Runtime\Collection\Collection.<br><br><b>src/Pyz/Zed/Oauth/OauthDependencyProvider.php</b><br>Method Pyz\Zed\Oauth\OauthDependencyProvider::getOauthRequestGrantTypeConfigurationProviderPlugins() should return array<Spryker\Zed\OauthExtension\Dependency\Plugin\OauthRequestGrantTypeConfigurationProviderPluginInterface> but returns array<int, Spryker\Zed\Oauth\Communication\Plugin\Oauth\CustomerPasswordOauthRequestGrantTypeConfigurationProviderPlugin\|Spryker\Zed\Oauth\Communication\Plugin\Oauth\UserPasswordOauthRequestGrantTypeConfigurationProviderPlugin\|Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\CustomerAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin\|Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\UserAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin\|Spryker\Zed\OauthWarehouse\Communication\Plugin\Oauth\WarehouseOauthRequestGrantTypeConfigurationProviderPlugin>.<br><br><b>src/Pyz/Zed/Oauth/OauthDependencyProvider.php</b><br>Instantiated class Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\UserAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin not found.<br><br><b>src/Pyz/Zed/Oauth/OauthDependencyProvider.php</b><br>Instantiated class Spryker\Zed\OauthCodeFlow\Communication\Plugin\Oauth\CustomerAuthCodeOauthRequestGrantTypeConfigurationProviderPlugin not found.<br><br><b>src/Pyz/Zed/ShipmentTypeStorage/ShipmentTypeStorageConfig.php</b><br>Access to constant PYZ_DEFAULT_SYNCHRONIZATION_POOL_NAME on an unknown class Pyz\Zed\ShipmentTypeStorage\SynchronizationConfig.<br><br><b>src/Pyz/Zed/StoreStorage/StoreStorageConfig.php</b><br>Access to constant PRODUCT_MEASUREMENT_UNIT_RESOURCE_NAME on an unknown class Spryker\Shared\ProductMeasurementUnitStorage\ProductMeasurementUnitStorageConfig.<br><br><b>src/Pyz/Zed/StoreStorage/StoreStorageConfig.php</b><br>Access to constant PRODUCT_PACKAGING_UNIT_RESOURCE_NAME on an unknown class Spryker\Shared\ProductPackagingUnitStorage\ProductPackagingUnitStorageConfig.<br><br><b>src/Pyz/Zed/StoreStorage/StoreStorageConfig.php</b><br>Access to constant COMPANY_USER_RESOURCE_NAME on an unknown class Spryker\Shared\CompanyUserStorage\CompanyUserStorageConfig.<br> | 

</details>

<details><summary><h4>We were not able to integrate these module versions</h4></summary>

| Package | Version | Message | 
|---------|------|--------|
 | **DateTimeConfiguratorPageExample** | 0.2.3 | Manifest for SprykerShop.DateTimeConfiguratorPageExample:0.2.3 was skipped. Target module SprykerShop/ProductConfigurationShoppingListWidget does not exists in your system. | 
 | **MerchantProductOfferWidget** | 2.1.0 | Manifest for SprykerShop.MerchantProductOfferWidget:2.1.0 was skipped. Target module SprykerShop/QuickOrderPage does not exists in your system. | 
 | **MerchantProductWidget** | 1.2.0 | Manifest for SprykerShop.MerchantProductWidget:1.2.0 was skipped. Target module SprykerShop/QuickOrderPage does not exists in your system. | 
 | **AssetStorage** | 1.0.0 | Manifest for Spryker.AssetStorage:1.0.0 was skipped. Method node not found | 
 | **Availability** | 9.19.0 | Manifest for Spryker.Availability:9.19.0 was skipped. Target module Spryker/DynamicEntity does not exists in your system. | 
 | **CustomerStorage** | 1.0.0 | Manifest for Spryker.CustomerStorage:1.0.0 was skipped. Method node not found | 
 | **ProductConfigurationsPriceProductVolumesRestApi** | 0.2.2 | Manifest for Spryker.ProductConfigurationsPriceProductVolumesRestApi:0.2.2 was skipped. Target module Spryker/ProductConfigurationShoppingListsRestApi does not exists in your system. | 
 | **ProductDiscontinued** | 1.0.0 | Manifest for Spryker.ProductDiscontinued:1.0.0 was skipped. Target module Spryker/ShoppingList does not exists in your system. | 
 | **Quote** | 2.16.0 | Manifest for Spryker.Quote:2.16.0 was skipped. Target module Spryker/Comment does not exists in your system. | 
 | **SessionRedis** | 1.6.0 | Manifest for Spryker.SessionRedis:1.6.0 was skipped. Target module Spryker/SessionCustomerValidation does not exists in your system. | 
 | **ShipmentTypeStorage** | 0.1.0 | Manifest for Spryker.ShipmentTypeStorage:0.1.0 was skipped. Method node not found | 
 | **StoreStorage** | 1.0.0 | Manifest for Spryker.StoreStorage:1.0.0 was skipped. Method node not found | 
</details>


<details><summary><h2>List of packages</h2></summary>

**Packages upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **composer/semver** | 3.3.2 | 3.4.0 | https://github.com/composer/semver/compare/3.3.2...3.4.0 | 
 | **doctrine/deprecations** | v1.1.1 | 1.1.2 | https://github.com/doctrine/deprecations/compare/v1.1.1...1.1.2 | 
 | **guzzlehttp/guzzle** | 7.7.0 | 7.8.1 | https://github.com/guzzle/guzzle/compare/7.7.0...7.8.1 | 
 | **guzzlehttp/psr7** | 2.5.0 | 2.6.2 | https://github.com/guzzle/psr7/compare/2.5.0...2.6.2 | 
 | **laminas/laminas-config** | 3.8.0 | 3.9.0 | https://github.com/laminas/laminas-config/compare/3.8.0...3.9.0 | 
 | **monolog/monolog** | 2.9.1 | 2.9.2 | https://github.com/Seldaek/monolog/compare/2.9.1...2.9.2 | 
 | **psr/http-client** | 1.0.2 | 1.0.3 | https://github.com/php-fig/http-client/compare/1.0.2...1.0.3 | 
 | **ramsey/uuid** | 4.7.4 | 4.7.5 | https://github.com/ramsey/uuid/compare/4.7.4...4.7.5 | 
 | **react/promise** | v2.10.0 | v2.11.0 | https://github.com/reactphp/promise/compare/v2.10.0...v2.11.0 | 
 | **spryker-sdk/evaluator** | 0.1.3 | 0.1.15 | https://github.com/spryker-sdk/evaluator/compare/0.1.3...0.1.15 | 
 | **spryker/application** | 3.32.1 | 3.34.0 | https://github.com/spryker/application/compare/3.32.1...3.34.0 | 
 | **spryker/availability** | 9.18.0 | 9.20.0 | https://github.com/spryker/availability/compare/9.18.0...9.20.0 | 
 | **spryker/category** | 5.13.0 | 5.14.0 | https://github.com/spryker/category/compare/5.13.0...5.14.0 | 
 | **spryker/chart** | 1.4.0 | 1.5.0 | https://github.com/spryker/chart/compare/1.4.0...1.5.0 | 
 | **spryker/customer** | 7.51.4 | 7.51.6 | https://github.com/spryker/customer/compare/7.51.4...7.51.6 | 
 | **spryker/error-handler** | 2.8.1 | 2.9.0 | https://github.com/spryker/error-handler/compare/2.8.1...2.9.0 | 
 | **spryker/glossary-storage** | 1.11.1 | 1.11.2 | https://github.com/spryker/glossary-storage/compare/1.11.1...1.11.2 | 
 | **spryker/gui** | 3.49.2 | 3.51.0 | https://github.com/spryker/gui/compare/3.49.2...3.51.0 | 
 | **spryker/locale** | 4.1.0 | 4.2.0 | https://github.com/spryker/locale/compare/4.1.0...4.2.0 | 
 | **spryker/message-broker** | 1.7.0 | 1.9.0 | https://github.com/spryker/message-broker/compare/1.7.0...1.9.0 | 
 | **spryker/message-broker-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/message-broker-extension/compare/1.1.0...1.2.0 | 
 | **spryker/oms** | 11.26.5 | 11.27.0 | https://github.com/spryker/oms/compare/11.26.5...11.27.0 | 
 | **spryker/product** | 6.36.3 | 6.37.0 | https://github.com/spryker/product/compare/6.36.3...6.37.0 | 
 | **spryker/product-image** | 3.16.0 | 3.17.0 | https://github.com/spryker/product-image/compare/3.16.0...3.17.0 | 
 | **spryker/router** | 1.15.1 | 1.17.0 | https://github.com/spryker/router/compare/1.15.1...1.17.0 | 
 | **spryker/sales** | 11.40.5 | 11.41.0 | https://github.com/spryker/sales/compare/11.40.5...11.41.0 | 
 | **spryker/search** | 8.20.0 | 8.21.1 | https://github.com/spryker/search/compare/8.20.0...8.21.1 | 
 | **spryker/search-extension** | 1.2.0 | 1.3.0 | https://github.com/spryker/search-extension/compare/1.2.0...1.3.0 | 
 | **spryker/shipment** | 8.15.2 | 8.18.0 | https://github.com/spryker/shipment/compare/8.15.2...8.18.0 | 
 | **spryker/shipment-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/shipment-extension/compare/1.1.0...1.2.0 | 
 | **spryker/stock** | 8.8.2 | 8.8.3 | https://github.com/spryker/stock/compare/8.8.2...8.8.3 | 
 | **spryker/storage** | 3.20.1 | 3.21.0 | https://github.com/spryker/storage/compare/3.20.1...3.21.0 | 
 | **spryker/store** | 1.20.0 | 1.23.1 | https://github.com/spryker/store/compare/1.20.0...1.23.1 | 
 | **spryker/twig** | 3.18.1 | 3.18.2 | https://github.com/spryker/twig/compare/3.18.1...3.18.2 | 
 | **spryker/util-date-time** | 1.4.0 | 1.4.1 | https://github.com/spryker/util-date-time/compare/1.4.0...1.4.1 | 
 | **spryker/zed-request** | 3.19.0 | 3.20.0 | https://github.com/spryker/zed-request/compare/3.19.0...3.20.0 | 
 | **symfony/flex** | v2.3.1 | v2.4.2 | https://github.com/symfony/flex/compare/v2.3.1...v2.4.2 | 
 | **symfony/monolog-bridge** | v5.4.22 | v5.4.31 | https://github.com/symfony/monolog-bridge/compare/v5.4.22...v5.4.31 | 
 | **symfony/monolog-bundle** | v3.8.0 | v3.10.0 | https://github.com/symfony/monolog-bundle/compare/v3.8.0...v3.10.0 | 
 | **symfony/polyfill-intl-grapheme** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-grapheme/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-icu** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-icu/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-idn** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-idn/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-normalizer** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-normalizer/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-mbstring** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-mbstring/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php73** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php73/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php80** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php80/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php81** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php81/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-uuid** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-uuid/compare/v1.27.0...v1.28.0 | 
 | **symfony/security-core** | v5.4.22 | v5.4.30 | https://github.com/symfony/security-core/compare/v5.4.22...v5.4.30 | 
 | **symfony/security-guard** | v5.4.22 | v5.4.27 | https://github.com/symfony/security-guard/compare/v5.4.22...v5.4.27 | 
 | **symfony/security-http** | v5.4.23 | v5.4.31 | https://github.com/symfony/security-http/compare/v5.4.23...v5.4.31 | 
 | **twig/twig** | v3.6.1 | v3.8.0 | https://github.com/twigphp/Twig/compare/v3.6.1...v3.8.0 | 
 | **voku/anti-xss** | 4.1.41 | 4.1.42 | https://github.com/voku/anti-xss/compare/4.1.41...4.1.42 | 
 | **spryker-sdk/utils** | NEW | 0.1.2 |  | 
 | **spryker/dynamic-entity-extension** | NEW | 1.0.0 |  | 
 | **spryker/willdurand-negotiation** | NEW | 1.0.0 |  | 
 | **spryker/chart** | 1.5.0 | 1.6.0 | https://github.com/spryker/chart/compare/1.5.0...1.6.0 | 

**Packages dev upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **filp/whoops** | 2.15.2 | 2.15.4 | https://github.com/filp/whoops/compare/2.15.2...2.15.4 | 
 | **phpstan/phpdoc-parser** | 1.22.1 | 1.24.4 | https://github.com/phpstan/phpdoc-parser/compare/1.22.1...1.24.4 | 

</details>


### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/scu/dev/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: 52cb57a5-5fcd-45f0-8fb1-74c9ba620567