### PR TITLE
Auto-updating Spryker modules on 2024-07-22 12:08

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10537,16 +10537,16 @@
         },
         {
             "name": "spryker-shop/customer-page",
-            "version": "2.47.0",
+            "version": "2.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/customer-page.git",
-                "reference": "fccadb383a9e85054e918f7d2a010f888710ed39"
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/fccadb383a9e85054e918f7d2a010f888710ed39",
-                "reference": "fccadb383a9e85054e918f7d2a010f888710ed39",
+                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/08ba64b07809edc26c5865c3289f50ccefeb744a",
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a",
                 "shasum": ""
             },
             "require": {
@@ -10563,11 +10563,13 @@
                 "spryker/quote": "^1.0.0 || ^2.1.0",
                 "spryker/router": "^1.6.0",
                 "spryker/sales": "^8.15.0 || ^10.0.0 || ^11.8.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/shipment": "^7.0.0 || ^8.0.0",
                 "spryker/step-engine": "^3.3.0",
                 "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.1.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/twig": "^3.18.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-validate": "^1.0.0"
@@ -10628,9 +10630,9 @@
             ],
             "description": "CustomerPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/customer-page/tree/2.47.0"
+                "source": "https://github.com/spryker-shop/customer-page/tree/2.49.0"
             },
-            "time": "2023-11-02T20:09:30+00:00"
+            "time": "2023-11-24T22:16:29+00:00"
         },
         {
             "name": "spryker-shop/customer-page-extension",
@@ -25289,16 +25291,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.52.0",
+            "version": "7.53.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "1528274b54d1eb1bfbf0da8c29fae4da2f248696"
+                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/1528274b54d1eb1bfbf0da8c29fae4da2f248696",
-                "reference": "1528274b54d1eb1bfbf0da8c29fae4da2f248696",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/3a201143cb7b4033f11a2050120d4bd744c160eb",
+                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb",
                 "shasum": ""
             },
             "require": {
@@ -25365,9 +25367,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.52.0"
+                "source": "https://github.com/spryker/customer/tree/7.53.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/customer-access",
@@ -52461,16 +52463,16 @@
         },
         {
             "name": "spryker/security-gui",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-gui.git",
-                "reference": "45c1be9a89726a82a71c31afd4a472fc21d2a190"
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-gui/zipball/45c1be9a89726a82a71c31afd4a472fc21d2a190",
-                "reference": "45c1be9a89726a82a71c31afd4a472fc21d2a190",
+                "url": "https://api.github.com/repos/spryker/security-gui/zipball/6ed419c3267d56e6bc91abea2268926943c28719",
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719",
                 "shasum": ""
             },
             "require": {
@@ -52478,6 +52480,7 @@
                 "spryker/kernel": "^3.30.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/security": "^1.3.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-gui-extension": "^1.2.0",
                 "spryker/symfony": "^3.5.0",
@@ -52519,9 +52522,9 @@
             ],
             "description": "SecurityGui module",
             "support": {
-                "source": "https://github.com/spryker/security-gui/tree/1.4.0"
+                "source": "https://github.com/spryker/security-gui/tree/1.5.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/security-gui-extension",
@@ -52566,25 +52569,26 @@
         },
         {
             "name": "spryker/security-merchant-portal-gui",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-merchant-portal-gui.git",
-                "reference": "b04d69d73b793a8afdf66ba057efb0682c22f65f"
+                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/b04d69d73b793a8afdf66ba057efb0682c22f65f",
-                "reference": "b04d69d73b793a8afdf66ba057efb0682c22f65f",
+                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/dddee33c56f44783e290d8a4d006202ec52a805e",
+                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/merchant-user": "^1.0.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/security": "^1.5.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-merchant-portal-gui-extension": "^1.0.0",
                 "spryker/symfony": "^3.5.0",
@@ -52628,9 +52632,9 @@
             ],
             "description": "SecurityMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.1.0"
+                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.2.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/security-merchant-portal-gui-extension",
@@ -57995,22 +57999,23 @@
         },
         {
             "name": "spryker/user-password-reset",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user-password-reset.git",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450"
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/c2cbea430658f1d4a0b4f110018e43d4cdcac450",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450",
+                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
+                "spryker/propel-orm": "^1.0.0",
                 "spryker/transfer": "^3.27.0",
                 "spryker/user": "^3.17.0",
                 "spryker/user-password-reset-extension": "^1.0.0",
@@ -58038,9 +58043,9 @@
             ],
             "description": "UserPasswordReset module",
             "support": {
-                "source": "https://github.com/spryker/user-password-reset/tree/1.4.0"
+                "source": "https://github.com/spryker/user-password-reset/tree/1.5.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/user-password-reset-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -464,87 +464,6 @@
             "time": "2022-04-20T14:46:44+00:00"
         },
         {
-            "name": "composer/semver",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-08-31T09:50:34+00:00"
-        },
-        {
             "name": "defuse/php-encryption",
             "version": "v2.4.0",
             "source": {
@@ -613,16 +532,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
-                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
                 "shasum": ""
             },
             "require": {
@@ -654,22 +573,22 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
             },
-            "time": "2023-09-27T20:04:15+00:00"
+            "time": "2024-01-30T19:34:25+00:00"
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.8",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff"
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
                 "shasum": ""
             },
             "require": {
@@ -731,7 +650,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.8"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
             },
             "funding": [
                 {
@@ -747,20 +666,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-16T13:40:37+00:00"
+            "time": "2024-02-18T20:23:39+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
+                "reference": "861c870e8b75f7c8f69c146c7f89cc1c0f1b49b6",
                 "shasum": ""
             },
             "require": {
@@ -768,11 +687,11 @@
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
+                "doctrine/coding-standard": "^9 || ^12",
                 "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
                 "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
+                "vimeo/psalm": "^4.11 || ^5.21"
             },
             "type": "library",
             "autoload": {
@@ -809,7 +728,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "source": "https://github.com/doctrine/lexer/tree/2.1.1"
             },
             "funding": [
                 {
@@ -825,7 +744,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2024-02-05T11:35:39+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -899,7 +818,7 @@
             "version": "v7.17.2",
             "source": {
                 "type": "git",
-                "url": "git@github.com:elastic/elasticsearch-php.git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
                 "reference": "2d302233f2bb0926812d82823bb820d405e130fc"
             },
             "dist": {
@@ -955,6 +874,10 @@
                 "elasticsearch",
                 "search"
             ],
+            "support": {
+                "issues": "https://github.com/elastic/elasticsearch-php/issues",
+                "source": "https://github.com/elastic/elasticsearch-php/tree/v7.17.2"
+            },
             "time": "2023-04-21T15:31:12+00:00"
         },
         {
@@ -1307,22 +1230,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.8.0",
+            "version": "7.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
+                "reference": "a629e5b69db96eb4939c1b34114130077dd4c6fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
-                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a629e5b69db96eb4939c1b34114130077dd4c6fc",
+                "reference": "a629e5b69db96eb4939c1b34114130077dd4c6fc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
+                "guzzlehttp/psr7": "^2.7.0",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -1331,11 +1254,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "guzzle/client-integration-tests": "3.0.2",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1413,7 +1336,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.1"
             },
             "funding": [
                 {
@@ -1429,28 +1352,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-27T10:20:53+00:00"
+            "time": "2024-07-19T16:19:57+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
-                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
             },
             "type": "library",
             "extra": {
@@ -1496,7 +1419,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.1"
+                "source": "https://github.com/guzzle/promises/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1512,20 +1435,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T15:11:55+00:00"
+            "time": "2024-07-18T10:29:17+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
-                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
                 "shasum": ""
             },
             "require": {
@@ -1539,9 +1462,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1612,7 +1535,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
             },
             "funding": [
                 {
@@ -1628,7 +1551,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-27T10:13:57+00:00"
+            "time": "2024-07-18T11:15:46+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1830,16 +1753,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.33.0",
+            "version": "2.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "6ad64828d25ec4bdf226ec5096aabb04aa710324"
+                "reference": "307afc21ada0648e84cdcf9e14cd84bd43ee9d13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/6ad64828d25ec4bdf226ec5096aabb04aa710324",
-                "reference": "6ad64828d25ec4bdf226ec5096aabb04aa710324",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/307afc21ada0648e84cdcf9e14cd84bd43ee9d13",
+                "reference": "307afc21ada0648e84cdcf9e14cd84bd43ee9d13",
                 "shasum": ""
             },
             "require": {
@@ -1854,14 +1777,14 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.10",
-                "laminas/laminas-i18n": "^2.23.1",
+                "laminas/laminas-crypt": "^3.11",
+                "laminas/laminas-i18n": "^2.26.0",
                 "laminas/laminas-uri": "^2.11",
-                "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-factory": "^1.0.2",
-                "vimeo/psalm": "^5.15.0"
+                "pear/archive_tar": "^1.5.0",
+                "phpunit/phpunit": "^10.5.20",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.24.0"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -1905,7 +1828,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-03T13:29:10+00:00"
+            "time": "2024-06-13T10:31:36+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -1999,16 +1922,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.18.0",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf"
+                "reference": "6a192dd0882b514e45506f533b833b623b78fff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/6a192dd0882b514e45506f533b833b623b78fff3",
+                "reference": "6a192dd0882b514e45506f533b833b623b78fff3",
                 "shasum": ""
             },
             "require": {
@@ -2019,10 +1942,10 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.5",
-                "phpbench/phpbench": "^1.2.14",
-                "phpunit/phpunit": "^10.3.3",
+                "phpbench/phpbench": "^1.2.15",
+                "phpunit/phpunit": "^10.5.8",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "vimeo/psalm": "^5.20.0"
             },
             "type": "library",
             "autoload": {
@@ -2054,7 +1977,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-09-19T10:15:21+00:00"
+            "time": "2024-01-19T12:39:49+00:00"
         },
         {
             "name": "laminas/laminas-validator",
@@ -2718,16 +2641,16 @@
         },
         {
             "name": "league/uri",
-            "version": "7.3.0",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "36743c3961bb82bf93da91917b6bced0358a8d45"
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/36743c3961bb82bf93da91917b6bced0358a8d45",
-                "reference": "36743c3961bb82bf93da91917b6bced0358a8d45",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
                 "shasum": ""
             },
             "require": {
@@ -2796,7 +2719,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.3.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.4.1"
             },
             "funding": [
                 {
@@ -2804,20 +2727,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-09T17:21:43+00:00"
+            "time": "2024-03-23T07:42:40+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.3.0",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c409b60ed2245ff94c965a8c798a60166db53361"
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c409b60ed2245ff94c965a8c798a60166db53361",
-                "reference": "c409b60ed2245ff94c965a8c798a60166db53361",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/8d43ef5c841032c87e2de015972c06f3865ef718",
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718",
                 "shasum": ""
             },
             "require": {
@@ -2880,7 +2803,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.3.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.4.1"
             },
             "funding": [
                 {
@@ -2888,7 +2811,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-09T17:21:43+00:00"
+            "time": "2024-03-23T07:42:40+00:00"
         },
         {
             "name": "minishlink/web-push",
@@ -3045,16 +2968,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.9.2",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
+                "reference": "a30bfe2e142720dfa990d0a7e573997f5d884215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a30bfe2e142720dfa990d0a7e573997f5d884215",
+                "reference": "a30bfe2e142720dfa990d0a7e573997f5d884215",
                 "shasum": ""
             },
             "require": {
@@ -3075,8 +2998,8 @@
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5.14",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5.38 || ^9.6.19",
                 "predis/predis": "^1.1 || ^2.0",
                 "rollbar/rollbar": "^1.3 || ^2 || ^3",
                 "ruflin/elastica": "^7",
@@ -3131,7 +3054,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.3"
             },
             "funding": [
                 {
@@ -3143,7 +3066,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-27T15:25:26+00:00"
+            "time": "2024-04-12T20:52:51+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -4024,20 +3947,20 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
@@ -4061,7 +3984,7 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -4073,9 +3996,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2023-04-10T20:10:41+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4315,20 +4238,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.4",
+            "version": "4.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286"
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/60a4c63ab724854332900504274f6150ff26d286",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -4391,7 +4314,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.4"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
             },
             "funding": [
                 {
@@ -4403,27 +4326,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-15T23:01:58+00:00"
+            "time": "2024-04-27T21:32:50+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -4467,7 +4390,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
@@ -4475,7 +4398,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-05-02T15:15:43+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "riskio/oauth2-auth0",
@@ -4532,16 +4455,16 @@
         },
         {
             "name": "ruflin/elastica",
-            "version": "7.3.1",
+            "version": "7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "7c61a630c3d456b00a5610960ae3a9bd29987469"
+                "reference": "84ba137678707a1aa4242d12bad891dc38fa2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/7c61a630c3d456b00a5610960ae3a9bd29987469",
-                "reference": "7c61a630c3d456b00a5610960ae3a9bd29987469",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/84ba137678707a1aa4242d12bad891dc38fa2608",
+                "reference": "84ba137678707a1aa4242d12bad891dc38fa2608",
                 "shasum": ""
             },
             "require": {
@@ -4595,9 +4518,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ruflin/Elastica/issues",
-                "source": "https://github.com/ruflin/Elastica/tree/7.3.1"
+                "source": "https://github.com/ruflin/Elastica/tree/7.3.2"
             },
-            "time": "2023-04-21T09:04:46+00:00"
+            "time": "2024-03-11T14:11:50+00:00"
         },
         {
             "name": "seld/signal-handler",
@@ -8324,140 +8247,17 @@
             "time": "2023-11-21T13:26:37+00:00"
         },
         {
-            "name": "spryker-sdk/evaluator",
-            "version": "0.1.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spryker-sdk/evaluator.git",
-                "reference": "e875c3ff60eb09c192f4ca7d8c2cee7d8bb5c0ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/evaluator/zipball/e875c3ff60eb09c192f4ca7d8c2cee7d8bb5c0ca",
-                "reference": "e875c3ff60eb09c192f4ca7d8c2cee7d8bb5c0ca",
-                "shasum": ""
-            },
-            "require": {
-                "composer/semver": "^3.3",
-                "ext-ctype": "*",
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "guzzlehttp/guzzle": "^7.5",
-                "laminas/laminas-filter": "^2.11.0",
-                "php": ">=7.4",
-                "spryker-sdk/security-checker": "^0.2.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dotenv": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/flex": "^1.17|^2",
-                "symfony/framework-bundle": "^5.4|^6.0",
-                "symfony/monolog-bundle": "^3.8",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/runtime": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "conflict": {
-                "symfony/symfony": "*"
-            },
-            "replace": {
-                "symfony/polyfill-ctype": "*",
-                "symfony/polyfill-iconv": "*",
-                "symfony/polyfill-php72": "*"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.6",
-                "spryker/code-sniffer": "^0.17.18"
-            },
-            "bin": [
-                "bin/evaluator"
-            ],
-            "type": "project",
-            "extra": {
-                "symfony": {
-                    "allow-contrib": false,
-                    "require": "^5.4|^6.0"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SprykerSdk\\Evaluator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "proprietary"
-            ],
-            "description": "The tool for evaluating Spryker shops",
-            "support": {
-                "issues": "https://github.com/spryker-sdk/evaluator/issues",
-                "source": "https://github.com/spryker-sdk/evaluator/tree/0.1.11"
-            },
-            "time": "2023-10-09T13:31:51+00:00"
-        },
-        {
-            "name": "spryker-sdk/security-checker",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spryker-sdk/security-checker.git",
-                "reference": "619c9c636590e0bef836f1c9ab1203ac9a66c46c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/security-checker/zipball/619c9c636590e0bef836f1c9ab1203ac9a66c46c",
-                "reference": "619c9c636590e0bef836f1c9ab1203ac9a66c46c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "symfony/console": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                "symfony/options-resolver": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                "symfony/process": "^4.0.0 || ^5.0.0 || ^6.0.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.2.0",
-                "slevomat/coding-standard": "^6.2",
-                "spryker/code-sniffer": "^0.15.6",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SecurityChecker\\": "src/SecurityChecker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "proprietary"
-            ],
-            "description": "A security checker for your composer.lock",
-            "support": {
-                "issues": "https://github.com/spryker-sdk/security-checker/issues",
-                "source": "https://github.com/spryker-sdk/security-checker/tree/0.2.0"
-            },
-            "time": "2023-04-24T11:24:18+00:00"
-        },
-        {
             "name": "spryker-shop/agent-page",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/agent-page.git",
-                "reference": "31debfad74bb7ddb5fdf7fb1ea5bbe96397acb83"
+                "reference": "e53b075d1229af5086447cb812fa8a642f3e1906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/agent-page/zipball/31debfad74bb7ddb5fdf7fb1ea5bbe96397acb83",
-                "reference": "31debfad74bb7ddb5fdf7fb1ea5bbe96397acb83",
+                "url": "https://api.github.com/repos/spryker-shop/agent-page/zipball/e53b075d1229af5086447cb812fa8a642f3e1906",
+                "reference": "e53b075d1229af5086447cb812fa8a642f3e1906",
                 "shasum": ""
             },
             "require": {
@@ -8491,8 +8291,6 @@
                 "spryker/testify": "*"
             },
             "suggest": {
-                "spryker/container": "Add this module to use the ContainerInterface.",
-                "spryker/security": "Add this module to use the SecurityPlugin.",
                 "spryker/silex": "Use this module when using plugins that need Silex dependencies."
             },
             "type": "library",
@@ -8512,9 +8310,9 @@
             ],
             "description": "AgentPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/agent-page/tree/1.13.0"
+                "source": "https://github.com/spryker-shop/agent-page/tree/1.14.0"
             },
-            "time": "2023-11-02T20:09:30+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/agent-page-extension",
@@ -9382,16 +9180,16 @@
         },
         {
             "name": "spryker-shop/checkout-page",
-            "version": "3.29.1",
+            "version": "3.30.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/checkout-page.git",
-                "reference": "ca6146dda8aba906f766c32fa76132dbf8315d1c"
+                "reference": "c03db519bed3c8f3a1c6b60c6e9f4e5e85dbee2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/ca6146dda8aba906f766c32fa76132dbf8315d1c",
-                "reference": "ca6146dda8aba906f766c32fa76132dbf8315d1c",
+                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/c03db519bed3c8f3a1c6b60c6e9f4e5e85dbee2d",
+                "reference": "c03db519bed3c8f3a1c6b60c6e9f4e5e85dbee2d",
                 "shasum": ""
             },
             "require": {
@@ -9400,7 +9198,7 @@
                 "spryker-shop/customer-page": "^2.46.0",
                 "spryker-shop/money-widget": "^1.0.0",
                 "spryker-shop/shop-application": "^1.0.0",
-                "spryker-shop/shop-ui": "^1.40.0",
+                "spryker-shop/shop-ui": "^1.73.1",
                 "spryker/application": "^3.8.0",
                 "spryker/calculation": "^4.2.0",
                 "spryker/cart": "^4.3.0 || ^5.0.0 || ^7.0.0",
@@ -9439,13 +9237,14 @@
                 "spryker-shop/cart-code-widget": "If you want to use components from module CartCodeWidget or CheckoutVoucherFormWidget or CheckoutVoucherFormWidgetPlugin",
                 "spryker-shop/cart-note-widget": "If you want to use components from module CartNoteWidget or CartNoteQuoteItemNoteWidgetPlugin.",
                 "spryker-shop/checkout-widget": "Add the module if you want to use checkout widget",
-                "spryker-shop/company-widget": "Add the module if you want to use company widget, use the version >= 1.8.0",
+                "spryker-shop/company-widget": "Add the module if you want to use company widget, use the version >= 1.9.0",
                 "spryker-shop/configurable-bundle-widget": "Add the module if you want to use QuoteConfiguredBundleWidget.",
                 "spryker-shop/gift-card-widget": "Add the module if you want to use gift card widget",
                 "spryker-shop/merchant-widget": "If you want to use MerchantMetaSchemaWidget use the version >= 1.3.0",
                 "spryker-shop/order-custom-reference-widget": "Add the module if you want to use order custom reference functionality",
                 "spryker-shop/product-packaging-unit-widget": "If you want to use components from module ProductPackagingUnitWidget or SummaryProductPackagingUnitWidgetPlugin: ^0.5.2",
                 "spryker-shop/quote-request-widget": "If you want to use QuoteRequestActionsWidget: ^2.2.0",
+                "spryker-shop/service-point-widget": "Add the module if you want to use service point widget",
                 "spryker-shop/shipment-type-widget": "Add the module if you want to use ShipmentTypeAddressFormWidget.",
                 "spryker/router": "Use this module when you want to use the Router.",
                 "spryker/shipment-cart-connector": "If you want to use shipment totals in quote or shipment source prices, min version 2.1.0",
@@ -9468,9 +9267,9 @@
             ],
             "description": "CheckoutPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/checkout-page/tree/3.29.1"
+                "source": "https://github.com/spryker-shop/checkout-page/tree/3.30.4"
             },
-            "time": "2023-11-08T09:58:38+00:00"
+            "time": "2024-05-06T12:15:31+00:00"
         },
         {
             "name": "spryker-shop/checkout-page-extension",
@@ -10537,16 +10336,16 @@
         },
         {
             "name": "spryker-shop/customer-page",
-            "version": "2.49.0",
+            "version": "2.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/customer-page.git",
-                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a"
+                "reference": "6a62fc8848118b708f5682c77400fc775638bc3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/08ba64b07809edc26c5865c3289f50ccefeb744a",
-                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a",
+                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/6a62fc8848118b708f5682c77400fc775638bc3d",
+                "reference": "6a62fc8848118b708f5682c77400fc775638bc3d",
                 "shasum": ""
             },
             "require": {
@@ -10607,9 +10406,7 @@
                 "spryker-shop/sales-return-page": "Add the module if you want to use return-create-link molecule.",
                 "spryker-shop/sales-service-point-widget": "Add the module if you want to display the service point related information.",
                 "spryker/config": "Use this module when using plugins that need Config dependencies.",
-                "spryker/container": "If you want to use twig plugins.",
                 "spryker/messenger": "Use this module when using plugins that need Messenger dependencies.",
-                "spryker/security": "Add this module to use the SecurityPlugin.",
                 "spryker/shipment-cart-connector": "If you want to use shipment totals in quote or shipment source prices, min version 2.1.0",
                 "spryker/silex": "Use this module when using plugins that need Silex dependencies."
             },
@@ -10630,9 +10427,9 @@
             ],
             "description": "CustomerPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/customer-page/tree/2.49.0"
+                "source": "https://github.com/spryker-shop/customer-page/tree/2.51.0"
             },
-            "time": "2023-11-24T22:16:29+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/customer-page-extension",
@@ -14426,20 +14223,20 @@
         },
         {
             "name": "spryker-shop/security-blocker-page",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/security-blocker-page.git",
-                "reference": "c0f5ac3392b97e89ac40469df56fdd7be899cc94"
+                "reference": "07ee1d8e9d1c223d0bf3fd2151f93278c7048e74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/security-blocker-page/zipball/c0f5ac3392b97e89ac40469df56fdd7be899cc94",
-                "reference": "c0f5ac3392b97e89ac40469df56fdd7be899cc94",
+                "url": "https://api.github.com/repos/spryker-shop/security-blocker-page/zipball/07ee1d8e9d1c223d0bf3fd2151f93278c7048e74",
+                "reference": "07ee1d8e9d1c223d0bf3fd2151f93278c7048e74",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/glossary-storage": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -14473,9 +14270,9 @@
             ],
             "description": "SecurityBlockerPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/security-blocker-page/tree/1.1.0"
+                "source": "https://github.com/spryker-shop/security-blocker-page/tree/1.2.0"
             },
-            "time": "2023-07-20T06:54:36+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/service-point-cart-page",
@@ -14586,20 +14383,20 @@
         },
         {
             "name": "spryker-shop/session-agent-validation",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/session-agent-validation.git",
-                "reference": "4fc793d7327a66a286c8b129767c8ebc60e7d4fd"
+                "reference": "10bee287ab7f9ab24a9b30b000fa314c7fe9123d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/session-agent-validation/zipball/4fc793d7327a66a286c8b129767c8ebc60e7d4fd",
-                "reference": "4fc793d7327a66a286c8b129767c8ebc60e7d4fd",
+                "url": "https://api.github.com/repos/spryker-shop/session-agent-validation/zipball/10bee287ab7f9ab24a9b30b000fa314c7fe9123d",
+                "reference": "10bee287ab7f9ab24a9b30b000fa314c7fe9123d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker-shop/customer-page-extension": "^1.2.0",
                 "spryker-shop/session-agent-validation-extension": "^1.0.0",
                 "spryker/agent": "^1.4.0",
@@ -14636,9 +14433,9 @@
             ],
             "description": "SessionAgentValidation module",
             "support": {
-                "source": "https://github.com/spryker-shop/session-agent-validation/tree/1.1.0"
+                "source": "https://github.com/spryker-shop/session-agent-validation/tree/1.2.0"
             },
-            "time": "2023-04-25T15:38:45+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/session-agent-validation-extension",
@@ -14683,20 +14480,20 @@
         },
         {
             "name": "spryker-shop/session-customer-validation-page",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/session-customer-validation-page.git",
-                "reference": "066745370d710540b6759998c368d2a5e9d5888f"
+                "reference": "a3e2c80231164137c965e833f5ae13a37e650a9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/session-customer-validation-page/zipball/066745370d710540b6759998c368d2a5e9d5888f",
-                "reference": "066745370d710540b6759998c368d2a5e9d5888f",
+                "url": "https://api.github.com/repos/spryker-shop/session-customer-validation-page/zipball/a3e2c80231164137c965e833f5ae13a37e650a9b",
+                "reference": "a3e2c80231164137c965e833f5ae13a37e650a9b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker-shop/agent-page-extension": "^1.0.0",
                 "spryker-shop/session-customer-validation-page-extension": "^1.0.0",
                 "spryker/customer": "^7.0.0",
@@ -14733,9 +14530,9 @@
             ],
             "description": "SessionCustomerValidationPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/session-customer-validation-page/tree/1.0.0"
+                "source": "https://github.com/spryker-shop/session-customer-validation-page/tree/1.1.0"
             },
-            "time": "2022-12-13T15:22:32+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/session-customer-validation-page-extension",
@@ -15280,20 +15077,20 @@
         },
         {
             "name": "spryker-shop/shop-ui",
-            "version": "1.73.0",
+            "version": "1.75.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/shop-ui.git",
-                "reference": "ab79866fa9c9accd4d8b665e3a5ca0d52b8425bb"
+                "reference": "37e94b2bbece798d888c31d5954507047a3ff10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/ab79866fa9c9accd4d8b665e3a5ca0d52b8425bb",
-                "reference": "ab79866fa9c9accd4d8b665e3a5ca0d52b8425bb",
+                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/37e94b2bbece798d888c31d5954507047a3ff10e",
+                "reference": "37e94b2bbece798d888c31d5954507047a3ff10e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/form-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -15337,9 +15134,9 @@
             ],
             "description": "ShopUi module",
             "support": {
-                "source": "https://github.com/spryker-shop/shop-ui/tree/1.73.0"
+                "source": "https://github.com/spryker-shop/shop-ui/tree/1.75.0"
             },
-            "time": "2023-10-27T14:50:57+00:00"
+            "time": "2024-07-11T14:10:03+00:00"
         },
         {
             "name": "spryker-shop/shopping-list-page-extension",
@@ -15477,20 +15274,20 @@
         },
         {
             "name": "spryker-shop/store-widget",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/store-widget.git",
-                "reference": "65b9c5522bcb90aea322d4a2a52ab6d68b63181c"
+                "reference": "97bafa8862895442281e4a75046437800a62a44f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/store-widget/zipball/65b9c5522bcb90aea322d4a2a52ab6d68b63181c",
-                "reference": "65b9c5522bcb90aea322d4a2a52ab6d68b63181c",
+                "url": "https://api.github.com/repos/spryker-shop/store-widget/zipball/97bafa8862895442281e4a75046437800a62a44f",
+                "reference": "97bafa8862895442281e4a75046437800a62a44f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/session": "^4.0.0",
@@ -15523,9 +15320,9 @@
             ],
             "description": "StoreWidget module",
             "support": {
-                "source": "https://github.com/spryker-shop/store-widget/tree/1.1.0"
+                "source": "https://github.com/spryker-shop/store-widget/tree/1.2.0"
             },
-            "time": "2023-04-14T12:33:33+00:00"
+            "time": "2023-12-21T16:51:03+00:00"
         },
         {
             "name": "spryker-shop/tabs-widget",
@@ -15825,21 +15622,21 @@
         },
         {
             "name": "spryker/acl",
-            "version": "3.18.0",
+            "version": "3.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/acl.git",
-                "reference": "0e440cb5627f4db71a904c4f40256ca901430099"
+                "reference": "cb912c13f5bafca0a7eeb499c26cea9adb9f460f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/acl/zipball/0e440cb5627f4db71a904c4f40256ca901430099",
-                "reference": "0e440cb5627f4db71a904c4f40256ca901430099",
+                "url": "https://api.github.com/repos/spryker/acl/zipball/cb912c13f5bafca0a7eeb499c26cea9adb9f460f",
+                "reference": "cb912c13f5bafca0a7eeb499c26cea9adb9f460f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "spryker/acl-extension": "^1.1.0",
+                "spryker/acl-extension": "^1.2.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/config": "^3.0.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
@@ -15894,9 +15691,9 @@
             ],
             "description": "Acl module",
             "support": {
-                "source": "https://github.com/spryker/acl/tree/3.18.0"
+                "source": "https://github.com/spryker/acl/tree/3.20.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-27T09:53:01+00:00"
         },
         {
             "name": "spryker/acl-data-import",
@@ -16100,20 +15897,20 @@
         },
         {
             "name": "spryker/acl-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/acl-extension.git",
-                "reference": "229a3a3f84e65c7af95080a94b842cddecabbe98"
+                "reference": "92e5bfccde8d431d18bfa848a08e39028bd37297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/acl-extension/zipball/229a3a3f84e65c7af95080a94b842cddecabbe98",
-                "reference": "229a3a3f84e65c7af95080a94b842cddecabbe98",
+                "url": "https://api.github.com/repos/spryker/acl-extension/zipball/92e5bfccde8d431d18bfa848a08e39028bd37297",
+                "reference": "92e5bfccde8d431d18bfa848a08e39028bd37297",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -16135,9 +15932,9 @@
             ],
             "description": "AclExtension module",
             "support": {
-                "source": "https://github.com/spryker/acl-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/acl-extension/tree/1.2.0"
             },
-            "time": "2021-07-30T05:04:54+00:00"
+            "time": "2024-02-06T10:56:40+00:00"
         },
         {
             "name": "spryker/acl-merchant-portal",
@@ -16684,16 +16481,16 @@
         },
         {
             "name": "spryker/application",
-            "version": "3.35.0",
+            "version": "3.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/application.git",
-                "reference": "13e11fc1ed0e88968961d05deb4dd5c1788bbedc"
+                "reference": "e2813c114e3761da6fd8ecda4c00d4a8a14f3a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/application/zipball/13e11fc1ed0e88968961d05deb4dd5c1788bbedc",
-                "reference": "13e11fc1ed0e88968961d05deb4dd5c1788bbedc",
+                "url": "https://api.github.com/repos/spryker/application/zipball/e2813c114e3761da6fd8ecda4c00d4a8a14f3a78",
+                "reference": "e2813c114e3761da6fd8ecda4c00d4a8a14f3a78",
                 "shasum": ""
             },
             "require": {
@@ -16745,9 +16542,9 @@
             ],
             "description": "Application module",
             "support": {
-                "source": "https://github.com/spryker/application/tree/3.35.0"
+                "source": "https://github.com/spryker/application/tree/3.35.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-02-20T09:01:42+00:00"
         },
         {
             "name": "spryker/application-extension",
@@ -17295,16 +17092,16 @@
         },
         {
             "name": "spryker/availability",
-            "version": "9.21.0",
+            "version": "9.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/availability.git",
-                "reference": "8aaecdb24d48de99930017b4b9d8f312e5989fb5"
+                "reference": "778d6c83a75742e4206b459077c51e9c062f9845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/availability/zipball/8aaecdb24d48de99930017b4b9d8f312e5989fb5",
-                "reference": "8aaecdb24d48de99930017b4b9d8f312e5989fb5",
+                "url": "https://api.github.com/repos/spryker/availability/zipball/778d6c83a75742e4206b459077c51e9c062f9845",
+                "reference": "778d6c83a75742e4206b459077c51e9c062f9845",
                 "shasum": ""
             },
             "require": {
@@ -17361,9 +17158,9 @@
             ],
             "description": "Availability module",
             "support": {
-                "source": "https://github.com/spryker/availability/tree/9.21.0"
+                "source": "https://github.com/spryker/availability/tree/9.22.0"
             },
-            "time": "2023-11-17T11:31:39+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/availability-cart-connector",
@@ -19290,20 +19087,20 @@
         },
         {
             "name": "spryker/category",
-            "version": "5.14.0",
+            "version": "5.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/category.git",
-                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0"
+                "reference": "d002be8bb781ac745b395283728693be23f2d01c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/category/zipball/09187a8265547b2ef1493c03353c8a29a317fea0",
-                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0",
+                "url": "https://api.github.com/repos/spryker/category/zipball/d002be8bb781ac745b395283728693be23f2d01c",
+                "reference": "d002be8bb781ac745b395283728693be23f2d01c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/category-extension": "^1.2.0",
                 "spryker/event": "^2.3.0",
@@ -19341,9 +19138,9 @@
             ],
             "description": "Category module",
             "support": {
-                "source": "https://github.com/spryker/category/tree/5.14.0"
+                "source": "https://github.com/spryker/category/tree/5.17.0"
             },
-            "time": "2023-10-30T14:48:01+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/category-data-feed",
@@ -20463,20 +20260,20 @@
         },
         {
             "name": "spryker/cms",
-            "version": "7.13.0",
+            "version": "7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms.git",
-                "reference": "668de2363c8a54c02de9cca5b48eb3fb29368cb5"
+                "reference": "a1883f046c385d77565bff598ef6ee57dc62f2ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms/zipball/668de2363c8a54c02de9cca5b48eb3fb29368cb5",
-                "reference": "668de2363c8a54c02de9cca5b48eb3fb29368cb5",
+                "url": "https://api.github.com/repos/spryker/cms/zipball/a1883f046c385d77565bff598ef6ee57dc62f2ca",
+                "reference": "a1883f046c385d77565bff598ef6ee57dc62f2ca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/category": "^3.0.0 || ^4.0.0 || ^5.0.0",
                 "spryker/cms-extension": "^1.1.0",
                 "spryker/glossary": "^3.1.0",
@@ -20527,9 +20324,9 @@
             ],
             "description": "Cms module",
             "support": {
-                "source": "https://github.com/spryker/cms/tree/7.13.0"
+                "source": "https://github.com/spryker/cms/tree/7.14.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/cms-block",
@@ -22955,16 +22752,16 @@
         },
         {
             "name": "spryker/collector",
-            "version": "6.9.0",
+            "version": "6.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/collector.git",
-                "reference": "86dd1e6554ffdd26faf8a553ae6c9b188f47bf11"
+                "reference": "2b749a56f51fe0cec7bd013b974fa9c0112919ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/collector/zipball/86dd1e6554ffdd26faf8a553ae6c9b188f47bf11",
-                "reference": "86dd1e6554ffdd26faf8a553ae6c9b188f47bf11",
+                "url": "https://api.github.com/repos/spryker/collector/zipball/2b749a56f51fe0cec7bd013b974fa9c0112919ad",
+                "reference": "2b749a56f51fe0cec7bd013b974fa9c0112919ad",
                 "shasum": ""
             },
             "require": {
@@ -23010,26 +22807,26 @@
             ],
             "description": "Collector module",
             "support": {
-                "source": "https://github.com/spryker/collector/tree/6.9.0"
+                "source": "https://github.com/spryker/collector/tree/6.10.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/comment-extension",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/comment-extension.git",
-                "reference": "7fd05b251c3e4c87d5f033b37a41c0c47df72a81"
+                "reference": "766fc0adcf5e4dc4f886a56a9c761af5ce948154"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/comment-extension/zipball/7fd05b251c3e4c87d5f033b37a41c0c47df72a81",
-                "reference": "7fd05b251c3e4c87d5f033b37a41c0c47df72a81",
+                "url": "https://api.github.com/repos/spryker/comment-extension/zipball/766fc0adcf5e4dc4f886a56a9c761af5ce948154",
+                "reference": "766fc0adcf5e4dc4f886a56a9c761af5ce948154",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -23051,9 +22848,9 @@
             ],
             "description": "CommentExtension module",
             "support": {
-                "source": "https://github.com/spryker/comment-extension/tree/1.0.0"
+                "source": "https://github.com/spryker/comment-extension/tree/1.1.0"
             },
-            "time": "2022-06-21T09:05:42+00:00"
+            "time": "2024-03-27T10:11:29+00:00"
         },
         {
             "name": "spryker/config",
@@ -23755,20 +23552,20 @@
         },
         {
             "name": "spryker/console",
-            "version": "4.12.0",
+            "version": "4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/console.git",
-                "reference": "fc1274867489936df0a28f55ab61a803cf27daf9"
+                "reference": "9b5750f658f3fe9ab2e61c8c2891b4a312894165"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/console/zipball/fc1274867489936df0a28f55ab61a803cf27daf9",
-                "reference": "fc1274867489936df0a28f55ab61a803cf27daf9",
+                "url": "https://api.github.com/repos/spryker/console/zipball/9b5750f658f3fe9ab2e61c8c2891b4a312894165",
+                "reference": "9b5750f658f3fe9ab2e61c8c2891b4a312894165",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-entity-extension": "^0.1.0 || ^0.2.0 || ^1.0.0",
                 "spryker/application": "^3.23.0",
                 "spryker/application-extension": "^1.0.0",
@@ -23810,9 +23607,9 @@
             ],
             "description": "Console module",
             "support": {
-                "source": "https://github.com/spryker/console/tree/4.12.0"
+                "source": "https://github.com/spryker/console/tree/4.13.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2024-02-22T15:29:16+00:00"
         },
         {
             "name": "spryker/container",
@@ -24891,20 +24688,20 @@
         },
         {
             "name": "spryker/country",
-            "version": "4.1.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/country.git",
-                "reference": "98885772899f19fb0296734bd466db01ad7b4180"
+                "reference": "eea2fc1ad7dc266d38d39f26e9b2905336e17575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/country/zipball/98885772899f19fb0296734bd466db01ad7b4180",
-                "reference": "98885772899f19fb0296734bd466db01ad7b4180",
+                "url": "https://api.github.com/repos/spryker/country/zipball/eea2fc1ad7dc266d38d39f26e9b2905336e17575",
+                "reference": "eea2fc1ad7dc266d38d39f26e9b2905336e17575",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/checkout-rest-api-extension": "^1.2.0",
                 "spryker/gui": "^3.0.0",
@@ -24944,9 +24741,9 @@
             ],
             "description": "Country module",
             "support": {
-                "source": "https://github.com/spryker/country/tree/4.1.0"
+                "source": "https://github.com/spryker/country/tree/4.3.0"
             },
-            "time": "2023-05-04T11:09:49+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/country-data-import",
@@ -25082,20 +24879,20 @@
         },
         {
             "name": "spryker/currency",
-            "version": "4.0.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/currency.git",
-                "reference": "a075a871f2598905d0cdc7a97d0793c61f5d660a"
+                "reference": "b013161058e67bef2469700d78ce6b49ec9e0508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/currency/zipball/a075a871f2598905d0cdc7a97d0793c61f5d660a",
-                "reference": "a075a871f2598905d0cdc7a97d0793c61f5d660a",
+                "url": "https://api.github.com/repos/spryker/currency/zipball/b013161058e67bef2469700d78ce6b49ec9e0508",
+                "reference": "b013161058e67bef2469700d78ce6b49ec9e0508",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/application-extension": "^1.1.0",
                 "spryker/currency-extension": "^1.0.0",
@@ -25145,9 +24942,9 @@
             ],
             "description": "Currency module",
             "support": {
-                "source": "https://github.com/spryker/currency/tree/4.0.0"
+                "source": "https://github.com/spryker/currency/tree/4.2.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/currency-data-import",
@@ -25291,16 +25088,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.53.0",
+            "version": "7.55.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb"
+                "reference": "5133e3114b6e354c1e53bf59b0bf061f1bf6a4ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/3a201143cb7b4033f11a2050120d4bd744c160eb",
-                "reference": "3a201143cb7b4033f11a2050120d4bd744c160eb",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/5133e3114b6e354c1e53bf59b0bf061f1bf6a4ca",
+                "reference": "5133e3114b6e354c1e53bf59b0bf061f1bf6a4ca",
                 "shasum": ""
             },
             "require": {
@@ -25309,7 +25106,7 @@
                 "spryker/authorization-extension": "^1.0.0",
                 "spryker/checkout-extension": "^1.2.0",
                 "spryker/country": "^3.1.0 || ^4.0.0",
-                "spryker/customer-extension": "^1.4.0",
+                "spryker/customer-extension": "^1.5.0",
                 "spryker/gui": "^3.39.0",
                 "spryker/kernel": "^3.72.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -25367,26 +25164,26 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.53.0"
+                "source": "https://github.com/spryker/customer/tree/7.55.0"
             },
-            "time": "2023-11-24T22:16:26+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/customer-access",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer-access.git",
-                "reference": "be500eb19f1c4cb1ae4e310cd4c05ba1bfbea9b3"
+                "reference": "8c1763b0e931831f7da8ad8bbf395dddee61ddf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer-access/zipball/be500eb19f1c4cb1ae4e310cd4c05ba1bfbea9b3",
-                "reference": "be500eb19f1c4cb1ae4e310cd4c05ba1bfbea9b3",
+                "url": "https://api.github.com/repos/spryker/customer-access/zipball/8c1763b0e931831f7da8ad8bbf395dddee61ddf6",
+                "reference": "8c1763b0e931831f7da8ad8bbf395dddee61ddf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/propel-orm": "^1.5.0"
             },
@@ -25417,9 +25214,9 @@
             ],
             "description": "CustomerAccess module",
             "support": {
-                "source": "https://github.com/spryker/customer-access/tree/1.3.0"
+                "source": "https://github.com/spryker/customer-access/tree/1.4.0"
             },
-            "time": "2021-10-19T13:00:46+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/customer-access-gui",
@@ -25559,16 +25356,16 @@
         },
         {
             "name": "spryker/customer-access-storage",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer-access-storage.git",
-                "reference": "b21aa28a9737e983f24f67a832d8792eb3358d7b"
+                "reference": "37513e803012fde20e4a5cfdf5cfd6584a014312"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer-access-storage/zipball/b21aa28a9737e983f24f67a832d8792eb3358d7b",
-                "reference": "b21aa28a9737e983f24f67a832d8792eb3358d7b",
+                "url": "https://api.github.com/repos/spryker/customer-access-storage/zipball/37513e803012fde20e4a5cfdf5cfd6584a014312",
+                "reference": "37513e803012fde20e4a5cfdf5cfd6584a014312",
                 "shasum": ""
             },
             "require": {
@@ -25613,26 +25410,26 @@
             ],
             "description": "CustomerAccessStorage module",
             "support": {
-                "source": "https://github.com/spryker/customer-access-storage/tree/1.9.0"
+                "source": "https://github.com/spryker/customer-access-storage/tree/1.10.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/customer-extension",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer-extension.git",
-                "reference": "c2f0fdbae3479968b3ef297fe7371aeb0ae5b503"
+                "reference": "83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer-extension/zipball/c2f0fdbae3479968b3ef297fe7371aeb0ae5b503",
-                "reference": "c2f0fdbae3479968b3ef297fe7371aeb0ae5b503",
+                "url": "https://api.github.com/repos/spryker/customer-extension/zipball/83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20",
+                "reference": "83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -25654,9 +25451,9 @@
             ],
             "description": "CustomerExtension module",
             "support": {
-                "source": "https://github.com/spryker/customer-extension/tree/1.4.0"
+                "source": "https://github.com/spryker/customer-extension/tree/1.5.0"
             },
-            "time": "2022-07-11T13:46:05+00:00"
+            "time": "2023-12-11T16:59:08+00:00"
         },
         {
             "name": "spryker/customer-group",
@@ -27866,16 +27663,16 @@
         },
         {
             "name": "spryker/event-behavior",
-            "version": "1.27.0",
+            "version": "1.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/event-behavior.git",
-                "reference": "b16d0be5f191e84393df990050fa5ea229a954db"
+                "reference": "9ff9bc3e9b2443c91c500948461d3a3b455991a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/event-behavior/zipball/b16d0be5f191e84393df990050fa5ea229a954db",
-                "reference": "b16d0be5f191e84393df990050fa5ea229a954db",
+                "url": "https://api.github.com/repos/spryker/event-behavior/zipball/9ff9bc3e9b2443c91c500948461d3a3b455991a6",
+                "reference": "9ff9bc3e9b2443c91c500948461d3a3b455991a6",
                 "shasum": ""
             },
             "require": {
@@ -27937,7 +27734,7 @@
             "support": {
                 "source": "https://github.com/spryker/event-behavior"
             },
-            "time": "2023-11-16T13:02:56+00:00"
+            "time": "2024-06-18T09:07:30+00:00"
         },
         {
             "name": "spryker/event-dispatcher",
@@ -28813,16 +28610,16 @@
         },
         {
             "name": "spryker/glossary",
-            "version": "3.15.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary.git",
-                "reference": "cfbf8f105467830e77b5e3087c2e7bfef090ab73"
+                "reference": "e73646e8d2dd4c4dd03e931a6505c57b05f2c867"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary/zipball/cfbf8f105467830e77b5e3087c2e7bfef090ab73",
-                "reference": "cfbf8f105467830e77b5e3087c2e7bfef090ab73",
+                "url": "https://api.github.com/repos/spryker/glossary/zipball/e73646e8d2dd4c4dd03e931a6505c57b05f2c867",
+                "reference": "e73646e8d2dd4c4dd03e931a6505c57b05f2c867",
                 "shasum": ""
             },
             "require": {
@@ -28838,7 +28635,7 @@
                 "spryker/storage": "^3.0.0",
                 "spryker/symfony": "^3.5.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-text": "^1.1.0"
             },
             "require-dev": {
@@ -28879,9 +28676,9 @@
             ],
             "description": "Glossary module",
             "support": {
-                "source": "https://github.com/spryker/glossary/tree/3.15.0"
+                "source": "https://github.com/spryker/glossary/tree/3.17.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/glossary-storage",
@@ -29714,16 +29511,16 @@
         },
         {
             "name": "spryker/gui",
-            "version": "3.52.0",
+            "version": "3.53.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/gui.git",
-                "reference": "4877a889d98ed16336de583cd8772238fb53a1fd"
+                "reference": "cdf54c3fdde0300ca1d08557448f7c3aba5f511b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/gui/zipball/4877a889d98ed16336de583cd8772238fb53a1fd",
-                "reference": "4877a889d98ed16336de583cd8772238fb53a1fd",
+                "url": "https://api.github.com/repos/spryker/gui/zipball/cdf54c3fdde0300ca1d08557448f7c3aba5f511b",
+                "reference": "cdf54c3fdde0300ca1d08557448f7c3aba5f511b",
                 "shasum": ""
             },
             "require": {
@@ -29772,9 +29569,9 @@
             ],
             "description": "Gui module",
             "support": {
-                "source": "https://github.com/spryker/gui/tree/3.52.0"
+                "source": "https://github.com/spryker/gui/tree/3.53.2"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-04-03T13:26:42+00:00"
         },
         {
             "name": "spryker/gui-table",
@@ -29961,20 +29758,20 @@
         },
         {
             "name": "spryker/http",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/http.git",
-                "reference": "c672bd1352d96f49fc31830e90546b1a6c22169c"
+                "reference": "0afd9b0bb5db66dd2e729d4691388c274dbe2c24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/http/zipball/c672bd1352d96f49fc31830e90546b1a6c22169c",
-                "reference": "c672bd1352d96f49fc31830e90546b1a6c22169c",
+                "url": "https://api.github.com/repos/spryker/http/zipball/0afd9b0bb5db66dd2e729d4691388c274dbe2c24",
+                "reference": "0afd9b0bb5db66dd2e729d4691388c274dbe2c24",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/form-extension": "^1.0.0",
@@ -30016,9 +29813,9 @@
             ],
             "description": "Http module",
             "support": {
-                "source": "https://github.com/spryker/http/tree/1.10.0"
+                "source": "https://github.com/spryker/http/tree/1.11.0"
             },
-            "time": "2023-04-18T12:57:09+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/http-extension",
@@ -30292,16 +30089,16 @@
         },
         {
             "name": "spryker/kernel",
-            "version": "3.74.0",
+            "version": "3.74.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/kernel.git",
-                "reference": "326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292"
+                "reference": "0bbb32af6a02d752ceab8abdcb01c3693519821a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/kernel/zipball/326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292",
-                "reference": "326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292",
+                "url": "https://api.github.com/repos/spryker/kernel/zipball/0bbb32af6a02d752ceab8abdcb01c3693519821a",
+                "reference": "0bbb32af6a02d752ceab8abdcb01c3693519821a",
                 "shasum": ""
             },
             "require": {
@@ -30347,9 +30144,9 @@
             ],
             "description": "Kernel module",
             "support": {
-                "source": "https://github.com/spryker/kernel/tree/3.74.0"
+                "source": "https://github.com/spryker/kernel/tree/3.74.4"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-30T08:55:04+00:00"
         },
         {
             "name": "spryker/key-builder",
@@ -30433,20 +30230,20 @@
         },
         {
             "name": "spryker/locale",
-            "version": "4.2.0",
+            "version": "4.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/locale.git",
-                "reference": "d65201d202bb58790cd8872eae2d599040d14b45"
+                "reference": "7d76cacd8b8f8f690c1902d549761296837adf32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/locale/zipball/d65201d202bb58790cd8872eae2d599040d14b45",
-                "reference": "d65201d202bb58790cd8872eae2d599040d14b45",
+                "url": "https://api.github.com/repos/spryker/locale/zipball/7d76cacd8b8f8f690c1902d549761296837adf32",
+                "reference": "7d76cacd8b8f8f690c1902d549761296837adf32",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
@@ -30497,9 +30294,9 @@
             ],
             "description": "Locale module",
             "support": {
-                "source": "https://github.com/spryker/locale/tree/4.2.0"
+                "source": "https://github.com/spryker/locale/tree/4.6.0"
             },
-            "time": "2023-10-17T16:01:45+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/locale-data-import",
@@ -30647,16 +30444,16 @@
         },
         {
             "name": "spryker/log",
-            "version": "3.16.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/log.git",
-                "reference": "c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5"
+                "reference": "389ca0e0b1d5c4e7f5d998c35d8161833018e442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/log/zipball/c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5",
-                "reference": "c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5",
+                "url": "https://api.github.com/repos/spryker/log/zipball/389ca0e0b1d5c4e7f5d998c35d8161833018e442",
+                "reference": "389ca0e0b1d5c4e7f5d998c35d8161833018e442",
                 "shasum": ""
             },
             "require": {
@@ -30665,10 +30462,11 @@
                 "spryker/config": "^3.0.0",
                 "spryker/kernel": "^3.48.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/log-extension": "^1.0.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/queue": "^0.3.0 || ^1.0.0",
                 "spryker/symfony": "^3.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-network": "^1.0.0"
             },
             "require-dev": {
@@ -30698,9 +30496,51 @@
             ],
             "description": "Log module",
             "support": {
-                "source": "https://github.com/spryker/log/tree/3.16.0"
+                "source": "https://github.com/spryker/log/tree/3.17.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-07-09T11:33:28+00:00"
+        },
+        {
+            "name": "spryker/log-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/log-extension.git",
+                "reference": "c913c2fe050887fd3b833cfe1414c8de0b8b7c56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/log-extension/zipball/c913c2fe050887fd3b833cfe1414c8de0b8b7c56",
+                "reference": "c913c2fe050887fd3b833cfe1414c8de0b8b7c56",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "LogExtension module",
+            "support": {
+                "source": "https://github.com/spryker/log-extension/tree/1.0.0"
+            },
+            "time": "2024-07-09T11:33:28+00:00"
         },
         {
             "name": "spryker/mail",
@@ -34038,20 +33878,20 @@
         },
         {
             "name": "spryker/merchant-user",
-            "version": "1.4.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant-user.git",
-                "reference": "4a8d5300993d50358520e51e5c4496cb394131d0"
+                "reference": "95fd1116cf6d5c3e0efae6b7483f6d2fd2ba1a85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant-user/zipball/4a8d5300993d50358520e51e5c4496cb394131d0",
-                "reference": "4a8d5300993d50358520e51e5c4496cb394131d0",
+                "url": "https://api.github.com/repos/spryker/merchant-user/zipball/95fd1116cf6d5c3e0efae6b7483f6d2fd2ba1a85",
+                "reference": "95fd1116cf6d5c3e0efae6b7483f6d2fd2ba1a85",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/merchant": "^3.0.0",
@@ -34060,15 +33900,22 @@
                 "spryker/propel-orm": "^1.5.0",
                 "spryker/security-gui-extension": "^1.1.0",
                 "spryker/transfer": "^3.27.0",
+                "spryker/twig-extension": "^1.0.0",
                 "spryker/user": "^3.17.0",
                 "spryker/user-password-reset": "^1.0.0",
                 "spryker/util-text": "^1.3.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/merchant-profile": "*",
                 "spryker/propel": "*",
-                "spryker/testify": "*"
+                "spryker/testify": "*",
+                "spryker/twig": "*"
+            },
+            "suggest": {
+                "spryker/container": "If you want to use Twig plugins",
+                "spryker/twig": "If you want to use Twig plugins"
             },
             "type": "library",
             "extra": {
@@ -34088,9 +33935,9 @@
             ],
             "description": "MerchantUser module",
             "support": {
-                "source": "https://github.com/spryker/merchant-user/tree/1.4.0"
+                "source": "https://github.com/spryker/merchant-user/tree/1.6.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2024-04-30T08:06:39+00:00"
         },
         {
             "name": "spryker/merchant-user-extension",
@@ -34632,16 +34479,16 @@
         },
         {
             "name": "spryker/money",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/money.git",
-                "reference": "e9d8c0e8359c457075c50c75bca929a155991e99"
+                "reference": "3dc3e731062b3c2454eccd75287609dfa087739a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/money/zipball/e9d8c0e8359c457075c50c75bca929a155991e99",
-                "reference": "e9d8c0e8359c457075c50c75bca929a155991e99",
+                "url": "https://api.github.com/repos/spryker/money/zipball/3dc3e731062b3c2454eccd75287609dfa087739a",
+                "reference": "3dc3e731062b3c2454eccd75287609dfa087739a",
                 "shasum": ""
             },
             "require": {
@@ -34688,9 +34535,9 @@
             ],
             "description": "Money module",
             "support": {
-                "source": "https://github.com/spryker/money/tree/2.13.0"
+                "source": "https://github.com/spryker/money/tree/2.13.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-02-08T09:58:52+00:00"
         },
         {
             "name": "spryker/money-gui",
@@ -35316,20 +35163,20 @@
         },
         {
             "name": "spryker/oauth-agent-connector",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oauth-agent-connector.git",
-                "reference": "0b862f542401850ce3ceea75828ed1458febb2f5"
+                "reference": "82c7dbdf2a8b60bcfb5664cb4433742afe941402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oauth-agent-connector/zipball/0b862f542401850ce3ceea75828ed1458febb2f5",
-                "reference": "0b862f542401850ce3ceea75828ed1458febb2f5",
+                "url": "https://api.github.com/repos/spryker/oauth-agent-connector/zipball/82c7dbdf2a8b60bcfb5664cb4433742afe941402",
+                "reference": "82c7dbdf2a8b60bcfb5664cb4433742afe941402",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/http-message": "^1.0.0",
                 "spryker/agent": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -35365,9 +35212,9 @@
             ],
             "description": "OauthAgentConnector module",
             "support": {
-                "source": "https://github.com/spryker/oauth-agent-connector/tree/1.1.0"
+                "source": "https://github.com/spryker/oauth-agent-connector/tree/1.2.0"
             },
-            "time": "2023-04-25T15:38:42+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/oauth-api",
@@ -36145,19 +35992,20 @@
         },
         {
             "name": "spryker/oms",
-            "version": "11.28.0",
+            "version": "11.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oms.git",
-                "reference": "a8b5a3481a0ba5474e014d3d397eaee4410a7271"
+                "reference": "1298f8c26ef28e4fbb127d3f40949e6092188395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oms/zipball/a8b5a3481a0ba5474e014d3d397eaee4410a7271",
-                "reference": "a8b5a3481a0ba5474e014d3d397eaee4410a7271",
+                "url": "https://api.github.com/repos/spryker/oms/zipball/1298f8c26ef28e4fbb127d3f40949e6092188395",
+                "reference": "1298f8c26ef28e4fbb127d3f40949e6092188395",
                 "shasum": ""
             },
             "require": {
+                "ext-simplexml": "*",
                 "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/decimal-object": "^1.0.0",
@@ -36168,7 +36016,7 @@
                 "spryker/mail": "^4.6.0",
                 "spryker/mail-extension": "^1.0.0",
                 "spryker/message-broker": "^1.2.1",
-                "spryker/oms-extension": "^1.3.0",
+                "spryker/oms-extension": "^1.4.0",
                 "spryker/propel": "^3.28.0",
                 "spryker/propel-orm": "^1.16.0",
                 "spryker/sales": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
@@ -36211,9 +36059,9 @@
             ],
             "description": "Oms module",
             "support": {
-                "source": "https://github.com/spryker/oms/tree/11.28.0"
+                "source": "https://github.com/spryker/oms/tree/11.33.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-07-04T08:39:36+00:00"
         },
         {
             "name": "spryker/oms-discount-connector",
@@ -36266,21 +36114,21 @@
         },
         {
             "name": "spryker/oms-extension",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oms-extension.git",
-                "reference": "5351c4b6f3772cc01eea83816a69515ea320c2ab"
+                "reference": "fa6eb2df3a453ad03fcd93b8ce6ed342936f829a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oms-extension/zipball/5351c4b6f3772cc01eea83816a69515ea320c2ab",
-                "reference": "5351c4b6f3772cc01eea83816a69515ea320c2ab",
+                "url": "https://api.github.com/repos/spryker/oms-extension/zipball/fa6eb2df3a453ad03fcd93b8ce6ed342936f829a",
+                "reference": "fa6eb2df3a453ad03fcd93b8ce6ed342936f829a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "spryker/transfer": "^3.8.0"
+                "php": ">=8.1",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -36302,9 +36150,9 @@
             ],
             "description": "OmsExtension module",
             "support": {
-                "source": "https://github.com/spryker/oms-extension/tree/1.3.0"
+                "source": "https://github.com/spryker/oms-extension/tree/1.4.0"
             },
-            "time": "2020-06-23T16:50:44+00:00"
+            "time": "2023-12-29T11:01:15+00:00"
         },
         {
             "name": "spryker/oms-multi-thread",
@@ -36691,22 +36539,23 @@
         },
         {
             "name": "spryker/payment",
-            "version": "5.15.1",
+            "version": "5.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/payment.git",
-                "reference": "021492247441b948c4935042916a98c639a8f08d"
+                "reference": "4db95ed917ac81930fa8f33cebd950f23139fca2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/payment/zipball/021492247441b948c4935042916a98c639a8f08d",
-                "reference": "021492247441b948c4935042916a98c639a8f08d",
+                "url": "https://api.github.com/repos/spryker/payment/zipball/4db95ed917ac81930fa8f33cebd950f23139fca2",
+                "reference": "4db95ed917ac81930fa8f33cebd950f23139fca2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/http-message": "^1.0.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/application": "^3.0.0",
                 "spryker/checkout-extension": "^1.2.0",
                 "spryker/guzzle": "^2.2.0",
                 "spryker/kernel": "^3.30.0",
@@ -36755,9 +36604,9 @@
             ],
             "description": "Payment module",
             "support": {
-                "source": "https://github.com/spryker/payment/tree/5.15.1"
+                "source": "https://github.com/spryker/payment/tree/5.19.0"
             },
-            "time": "2023-10-17T13:19:18+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/payment-cart-connector",
@@ -37835,16 +37684,16 @@
         },
         {
             "name": "spryker/price-product",
-            "version": "4.43.1",
+            "version": "4.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price-product.git",
-                "reference": "153c34eafe6fe1084f5bf5ae1a96e3583231625c"
+                "reference": "cbc3d9fad51d946b9d48a8154d89ce789136296d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price-product/zipball/153c34eafe6fe1084f5bf5ae1a96e3583231625c",
-                "reference": "153c34eafe6fe1084f5bf5ae1a96e3583231625c",
+                "url": "https://api.github.com/repos/spryker/price-product/zipball/cbc3d9fad51d946b9d48a8154d89ce789136296d",
+                "reference": "cbc3d9fad51d946b9d48a8154d89ce789136296d",
                 "shasum": ""
             },
             "require": {
@@ -37901,9 +37750,9 @@
             ],
             "description": "PriceProduct module",
             "support": {
-                "source": "https://github.com/spryker/price-product/tree/4.43.1"
+                "source": "https://github.com/spryker/price-product/tree/4.44.1"
             },
-            "time": "2023-11-17T08:53:15+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/price-product-data-import",
@@ -38919,16 +38768,16 @@
         },
         {
             "name": "spryker/product",
-            "version": "6.38.0",
+            "version": "6.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product.git",
-                "reference": "59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9"
+                "reference": "a398be4f37f1cf4e924b345e92054f67ea34159f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product/zipball/59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9",
-                "reference": "59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9",
+                "url": "https://api.github.com/repos/spryker/product/zipball/a398be4f37f1cf4e924b345e92054f67ea34159f",
+                "reference": "a398be4f37f1cf4e924b345e92054f67ea34159f",
                 "shasum": ""
             },
             "require": {
@@ -38956,6 +38805,7 @@
             "require-dev": {
                 "spryker/code-sniffer": "*",
                 "spryker/container": "*",
+                "spryker/product-attribute": "*",
                 "spryker/product-image": "*",
                 "spryker/propel": "*",
                 "spryker/testify": "*"
@@ -38978,9 +38828,9 @@
             ],
             "description": "Product module",
             "support": {
-                "source": "https://github.com/spryker/product/tree/6.38.0"
+                "source": "https://github.com/spryker/product/tree/6.42.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-07-03T11:11:29+00:00"
         },
         {
             "name": "spryker/product-abstract-data-feed",
@@ -39842,16 +39692,16 @@
         },
         {
             "name": "spryker/product-bundle",
-            "version": "7.17.0",
+            "version": "7.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-bundle.git",
-                "reference": "87c1982852163375b94f064dccba07502e6ebe61"
+                "reference": "bddeb5d170d85892b47222c9e6f7ac7260083047"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/87c1982852163375b94f064dccba07502e6ebe61",
-                "reference": "87c1982852163375b94f064dccba07502e6ebe61",
+                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/bddeb5d170d85892b47222c9e6f7ac7260083047",
+                "reference": "bddeb5d170d85892b47222c9e6f7ac7260083047",
                 "shasum": ""
             },
             "require": {
@@ -39916,9 +39766,9 @@
             ],
             "description": "ProductBundle module",
             "support": {
-                "source": "https://github.com/spryker/product-bundle/tree/7.17.0"
+                "source": "https://github.com/spryker/product-bundle/tree/7.19.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/product-bundle-carts-rest-api",
@@ -40203,16 +40053,16 @@
         },
         {
             "name": "spryker/product-category",
-            "version": "4.22.0",
+            "version": "4.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-category.git",
-                "reference": "06609089cbe5abe9187c78608097adfa58c768a0"
+                "reference": "1888b91f1891d8ae981d1e09bdc2d23fae57341b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-category/zipball/06609089cbe5abe9187c78608097adfa58c768a0",
-                "reference": "06609089cbe5abe9187c78608097adfa58c768a0",
+                "url": "https://api.github.com/repos/spryker/product-category/zipball/1888b91f1891d8ae981d1e09bdc2d23fae57341b",
+                "reference": "1888b91f1891d8ae981d1e09bdc2d23fae57341b",
                 "shasum": ""
             },
             "require": {
@@ -40228,6 +40078,7 @@
                 "spryker/product": "^5.0.0 || ^6.0.0",
                 "spryker/product-extension": "^1.3.0",
                 "spryker/propel-orm": "^1.0.0",
+                "spryker/publisher-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-encoding": "^2.0.0"
@@ -40261,9 +40112,9 @@
             ],
             "description": "ProductCategory module",
             "support": {
-                "source": "https://github.com/spryker/product-category/tree/4.22.0"
+                "source": "https://github.com/spryker/product-category/tree/4.25.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/product-category-filter",
@@ -42025,20 +41876,20 @@
         },
         {
             "name": "spryker/product-image",
-            "version": "3.17.0",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-image.git",
-                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3"
+                "reference": "1ae36b0247edb3607acb82f48738232e9dc081a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-image/zipball/ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
-                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
+                "url": "https://api.github.com/repos/spryker/product-image/zipball/1ae36b0247edb3607acb82f48738232e9dc081a9",
+                "reference": "1ae36b0247edb3607acb82f48738232e9dc081a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -42072,9 +41923,9 @@
             ],
             "description": "ProductImage module",
             "support": {
-                "source": "https://github.com/spryker/product-image/tree/3.17.0"
+                "source": "https://github.com/spryker/product-image/tree/3.18.0"
             },
-            "time": "2023-07-17T12:04:54+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/product-image-cart-connector",
@@ -45612,16 +45463,16 @@
         },
         {
             "name": "spryker/product-option",
-            "version": "8.16.0",
+            "version": "8.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-option.git",
-                "reference": "c600a2fe6a16c7e030de5f5ffc237684bb85d886"
+                "reference": "efd38e5b8325ab7af0ff6cf48aed1b2cba52bf7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-option/zipball/c600a2fe6a16c7e030de5f5ffc237684bb85d886",
-                "reference": "c600a2fe6a16c7e030de5f5ffc237684bb85d886",
+                "url": "https://api.github.com/repos/spryker/product-option/zipball/efd38e5b8325ab7af0ff6cf48aed1b2cba52bf7b",
+                "reference": "efd38e5b8325ab7af0ff6cf48aed1b2cba52bf7b",
                 "shasum": ""
             },
             "require": {
@@ -45645,7 +45496,7 @@
                 "spryker/sales": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
                 "spryker/sales-extension": "^1.6.0",
                 "spryker/storage": "^3.0.0",
-                "spryker/store": "^1.1.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax": "^5.0.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
@@ -45695,9 +45546,9 @@
             ],
             "description": "ProductOption module",
             "support": {
-                "source": "https://github.com/spryker/product-option/tree/8.16.0"
+                "source": "https://github.com/spryker/product-option/tree/8.19.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/product-option-cart-connector",
@@ -47019,16 +46870,16 @@
         },
         {
             "name": "spryker/product-search",
-            "version": "5.20.0",
+            "version": "5.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-search.git",
-                "reference": "cb7a403c1c2405e335551b84a9fb68985aac46ec"
+                "reference": "4e74992e6664eb18ef9738481c3b2babf59b5116"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-search/zipball/cb7a403c1c2405e335551b84a9fb68985aac46ec",
-                "reference": "cb7a403c1c2405e335551b84a9fb68985aac46ec",
+                "url": "https://api.github.com/repos/spryker/product-search/zipball/4e74992e6664eb18ef9738481c3b2babf59b5116",
+                "reference": "4e74992e6664eb18ef9738481c3b2babf59b5116",
                 "shasum": ""
             },
             "require": {
@@ -47036,7 +46887,7 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/collector": "^5.1.1 || ^6.0.0",
                 "spryker/event": "^2.1.0",
-                "spryker/glossary": "^3.0.0",
+                "spryker/glossary": "^3.16.0",
                 "spryker/gui": "^3.33.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.1.0",
@@ -47050,7 +46901,7 @@
                 "spryker/store": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-data-reader": "^1.0.0"
             },
             "require-dev": {
@@ -47080,9 +46931,9 @@
             ],
             "description": "ProductSearch module",
             "support": {
-                "source": "https://github.com/spryker/product-search/tree/5.20.0"
+                "source": "https://github.com/spryker/product-search/tree/5.21.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/product-search-config-storage",
@@ -47860,16 +47711,16 @@
         },
         {
             "name": "spryker/propel",
-            "version": "3.39.0",
+            "version": "3.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel.git",
-                "reference": "7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585"
+                "reference": "6bd8f1d5ae4b31f28cde53795823cee4ad1311bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel/zipball/7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585",
-                "reference": "7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585",
+                "url": "https://api.github.com/repos/spryker/propel/zipball/6bd8f1d5ae4b31f28cde53795823cee4ad1311bc",
+                "reference": "6bd8f1d5ae4b31f28cde53795823cee4ad1311bc",
                 "shasum": ""
             },
             "require": {
@@ -47880,7 +47731,7 @@
                 "spryker/kernel": "^3.48.0",
                 "spryker/log": "^3.0.0",
                 "spryker/monolog": "^2.0.0",
-                "spryker/propel-orm": "^1.18.0",
+                "spryker/propel-orm": "^1.20.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.12.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -47916,26 +47767,26 @@
             ],
             "description": "Propel module",
             "support": {
-                "source": "https://github.com/spryker/propel/tree/3.39.0"
+                "source": "https://github.com/spryker/propel/tree/3.40.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-01-15T11:37:17+00:00"
         },
         {
             "name": "spryker/propel-orm",
-            "version": "1.19.0",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel-orm.git",
-                "reference": "aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8"
+                "reference": "e372e740ce43bc8a7fce52931d064ce60fc54157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8",
-                "reference": "aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8",
+                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/e372e740ce43bc8a7fce52931d064ce60fc54157",
+                "reference": "e372e740ce43bc8a7fce52931d064ce60fc54157",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "propel/propel": "2.0.0-beta3",
                 "spryker/config": "^3.0.0",
                 "spryker/error-handler": "^2.0.0",
@@ -47956,6 +47807,7 @@
             },
             "autoload": {
                 "psr-4": {
+                    "Propel\\": "src/Spryker/Zed/PropelOrm/Business/Polyfill/",
                     "Spryker\\": "src/Spryker/",
                     "SprykerTest\\Shared\\PropelOrm\\Helper\\": "tests/SprykerTest/Shared/PropelOrm/_support/Helper/"
                 }
@@ -47966,9 +47818,9 @@
             ],
             "description": "PropelOrm module",
             "support": {
-                "source": "https://github.com/spryker/propel-orm/tree/1.19.0"
+                "source": "https://github.com/spryker/propel-orm/tree/1.20.0"
             },
-            "time": "2023-04-18T11:16:52+00:00"
+            "time": "2024-01-15T11:37:17+00:00"
         },
         {
             "name": "spryker/propel-orm-extension",
@@ -49002,24 +48854,25 @@
         },
         {
             "name": "spryker/refund",
-            "version": "5.7.2",
+            "version": "5.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/refund.git",
-                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b"
+                "reference": "9e199929f30a574af9781a4b02d1b362a674dbdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/refund/zipball/108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
-                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
+                "url": "https://api.github.com/repos/spryker/refund/zipball/9e199929f30a574af9781a4b02d1b362a674dbdd",
+                "reference": "9e199929f30a574af9781a4b02d1b362a674dbdd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
                 "spryker/gui": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
+                "spryker/messenger": "^3.0.0",
                 "spryker/money": "^2.0.0",
                 "spryker/refund-extension": "^1.0.0",
                 "spryker/sales": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
@@ -49040,6 +48893,9 @@
                 "spryker/testify": "*",
                 "spryker/zed-navigation": "*"
             },
+            "suggest": {
+                "spryker/oms": "If you want to use Oms command plugins."
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -49057,9 +48913,9 @@
             ],
             "description": "Refund module",
             "support": {
-                "source": "https://github.com/spryker/refund/tree/5.7.2"
+                "source": "https://github.com/spryker/refund/tree/5.10.0"
             },
-            "time": "2023-06-06T15:14:45+00:00"
+            "time": "2024-06-24T13:52:12+00:00"
         },
         {
             "name": "spryker/refund-extension",
@@ -49203,16 +49059,16 @@
         },
         {
             "name": "spryker/router",
-            "version": "1.18.0",
+            "version": "1.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/router.git",
-                "reference": "d31caaad15db133fac32200280622ddd423d2b74"
+                "reference": "1500a3d0a87706f9ddda491f4b7537521ec10fd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/router/zipball/d31caaad15db133fac32200280622ddd423d2b74",
-                "reference": "d31caaad15db133fac32200280622ddd423d2b74",
+                "url": "https://api.github.com/repos/spryker/router/zipball/1500a3d0a87706f9ddda491f4b7537521ec10fd8",
+                "reference": "1500a3d0a87706f9ddda491f4b7537521ec10fd8",
                 "shasum": ""
             },
             "require": {
@@ -49256,9 +49112,9 @@
             ],
             "description": "Router module",
             "support": {
-                "source": "https://github.com/spryker/router/tree/1.18.0"
+                "source": "https://github.com/spryker/router/tree/1.19.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/router-extension",
@@ -49310,16 +49166,16 @@
         },
         {
             "name": "spryker/sales",
-            "version": "11.42.0",
+            "version": "11.49.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales.git",
-                "reference": "7600f8d0c08e79b97e10f1173d5c4065eadaeab4"
+                "reference": "53a49812394e172175e036f02e7d6b7b96123aa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales/zipball/7600f8d0c08e79b97e10f1173d5c4065eadaeab4",
-                "reference": "7600f8d0c08e79b97e10f1173d5c4065eadaeab4",
+                "url": "https://api.github.com/repos/spryker/sales/zipball/53a49812394e172175e036f02e7d6b7b96123aa6",
+                "reference": "53a49812394e172175e036f02e7d6b7b96123aa6",
                 "shasum": ""
             },
             "require": {
@@ -49336,7 +49192,7 @@
                 "spryker/oms": "^10.3.0 || ^11.0.0",
                 "spryker/propel": "^3.0.0",
                 "spryker/propel-orm": "^1.16.0",
-                "spryker/sales-extension": "^1.9.0",
+                "spryker/sales-extension": "^1.11.0",
                 "spryker/sales-split": "^3.0.0 || ^5.0.0",
                 "spryker/sequence-number": "^3.0.0",
                 "spryker/store": "^1.0.0",
@@ -49364,6 +49220,7 @@
             },
             "suggest": {
                 "spryker/checkout": "If you want to use Checkout plugins. ^4.0.0",
+                "spryker/sales-merchant-commission-merchant-portal-gui": "Use this module if you want to use templates with merchant commission totals.",
                 "spryker/sales-product-configuration-gui": "Add the module if you want to display order item configuration."
             },
             "type": "library",
@@ -49385,9 +49242,9 @@
             ],
             "description": "Sales module",
             "support": {
-                "source": "https://github.com/spryker/sales/tree/11.42.0"
+                "source": "https://github.com/spryker/sales/tree/11.49.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-06-28T09:07:50+00:00"
         },
         {
             "name": "spryker/sales-configurable-bundle",
@@ -49500,20 +49357,20 @@
         },
         {
             "name": "spryker/sales-extension",
-            "version": "1.9.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-extension.git",
-                "reference": "3e8555b4cb07dbe0543aae039a2f96b3a770fcd4"
+                "reference": "727780de837abd42902bd396c9a9a6f0824d6f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-extension/zipball/3e8555b4cb07dbe0543aae039a2f96b3a770fcd4",
-                "reference": "3e8555b4cb07dbe0543aae039a2f96b3a770fcd4",
+                "url": "https://api.github.com/repos/spryker/sales-extension/zipball/727780de837abd42902bd396c9a9a6f0824d6f93",
+                "reference": "727780de837abd42902bd396c9a9a6f0824d6f93",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -49535,9 +49392,9 @@
             ],
             "description": "SalesExtension module",
             "support": {
-                "source": "https://github.com/spryker/sales-extension/tree/1.9.0"
+                "source": "https://github.com/spryker/sales-extension/tree/1.11.0"
             },
-            "time": "2021-06-24T13:01:59+00:00"
+            "time": "2024-06-24T13:52:12+00:00"
         },
         {
             "name": "spryker/sales-invoice",
@@ -51500,16 +51357,16 @@
         },
         {
             "name": "spryker/search",
-            "version": "8.22.0",
+            "version": "8.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search.git",
-                "reference": "a59961ecc55f8b2f87dc3ad44e50cab992096bd1"
+                "reference": "fd2aad960a110c212e2df11bee24bf843333b113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search/zipball/a59961ecc55f8b2f87dc3ad44e50cab992096bd1",
-                "reference": "a59961ecc55f8b2f87dc3ad44e50cab992096bd1",
+                "url": "https://api.github.com/repos/spryker/search/zipball/fd2aad960a110c212e2df11bee24bf843333b113",
+                "reference": "fd2aad960a110c212e2df11bee24bf843333b113",
                 "shasum": ""
             },
             "require": {
@@ -51526,7 +51383,7 @@
                 "spryker/money": "^2.0.0",
                 "spryker/product-page-search-extension": "^1.0.0",
                 "spryker/search-extension": "^1.2.0",
-                "spryker/store": "^1.1.0",
+                "spryker/store": "^1.19.0",
                 "spryker/store-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
@@ -51562,9 +51419,9 @@
             ],
             "description": "Search module",
             "support": {
-                "source": "https://github.com/spryker/search/tree/8.22.0"
+                "source": "https://github.com/spryker/search/tree/8.23.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/search-elasticsearch",
@@ -51933,24 +51790,24 @@
         },
         {
             "name": "spryker/security",
-            "version": "1.7.1",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security.git",
-                "reference": "56bb645a4a30fbb0d0611e64f8e284eb9cee0d23"
+                "reference": "1de605712f5a8d4d299db180f7d281ce6266aff2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security/zipball/56bb645a4a30fbb0d0611e64f8e284eb9cee0d23",
-                "reference": "56bb645a4a30fbb0d0611e64f8e284eb9cee0d23",
+                "url": "https://api.github.com/repos/spryker/security/zipball/1de605712f5a8d4d299db180f7d281ce6266aff2",
+                "reference": "1de605712f5a8d4d299db180f7d281ce6266aff2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/security-extension": "^1.1.0",
-                "spryker/symfony": "^3.8.0",
+                "spryker/symfony": "^3.15.0",
                 "spryker/validator-extension": "^1.0.0"
             },
             "require-dev": {
@@ -51965,7 +51822,6 @@
                 "spryker/testify": "*"
             },
             "suggest": {
-                "spryker/container": "Add this module to use the Container.",
                 "spryker/event-dispatcher": "Add this module to use the EventDispatcher.",
                 "spryker/event-dispatcher-extension": "Add this module to use the EventDispatcherExtension.",
                 "spryker/log": "Add this module when you want to use the Logger."
@@ -51989,9 +51845,9 @@
             ],
             "description": "Security module",
             "support": {
-                "source": "https://github.com/spryker/security/tree/1.7.1"
+                "source": "https://github.com/spryker/security/tree/1.8.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-blocker",
@@ -52086,20 +51942,20 @@
         },
         {
             "name": "spryker/security-blocker-backoffice-gui",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-blocker-backoffice-gui.git",
-                "reference": "6fb790774528345610125f760ef9df464b1fcbc9"
+                "reference": "3e40406425d0fa6edb90a5c5074606210440e44e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-blocker-backoffice-gui/zipball/6fb790774528345610125f760ef9df464b1fcbc9",
-                "reference": "6fb790774528345610125f760ef9df464b1fcbc9",
+                "url": "https://api.github.com/repos/spryker/security-blocker-backoffice-gui/zipball/3e40406425d0fa6edb90a5c5074606210440e44e",
+                "reference": "3e40406425d0fa6edb90a5c5074606210440e44e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/glossary": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -52134,9 +51990,9 @@
             ],
             "description": "SecurityBlockerBackofficeGui module",
             "support": {
-                "source": "https://github.com/spryker/security-blocker-backoffice-gui/tree/1.0.0"
+                "source": "https://github.com/spryker/security-blocker-backoffice-gui/tree/1.1.0"
             },
-            "time": "2023-03-28T12:28:15+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-blocker-extension",
@@ -52226,20 +52082,20 @@
         },
         {
             "name": "spryker/security-blocker-merchant-portal-gui",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-blocker-merchant-portal-gui.git",
-                "reference": "758d3ef7d03eeb38729371c6b891b830287abc80"
+                "reference": "77a458a75b06d70fb49e52e5b982f8bbe003f04f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-blocker-merchant-portal-gui/zipball/758d3ef7d03eeb38729371c6b891b830287abc80",
-                "reference": "758d3ef7d03eeb38729371c6b891b830287abc80",
+                "url": "https://api.github.com/repos/spryker/security-blocker-merchant-portal-gui/zipball/77a458a75b06d70fb49e52e5b982f8bbe003f04f",
+                "reference": "77a458a75b06d70fb49e52e5b982f8bbe003f04f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/glossary": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -52274,9 +52130,9 @@
             ],
             "description": "SecurityBlockerMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/security-blocker-merchant-portal-gui/tree/1.0.0"
+                "source": "https://github.com/spryker/security-blocker-merchant-portal-gui/tree/1.1.0"
             },
-            "time": "2023-03-28T12:28:15+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-blocker-rest-api",
@@ -52463,23 +52319,23 @@
         },
         {
             "name": "spryker/security-gui",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-gui.git",
-                "reference": "6ed419c3267d56e6bc91abea2268926943c28719"
+                "reference": "bee29d901c596035d6a5b7001a02034c61c2a14e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-gui/zipball/6ed419c3267d56e6bc91abea2268926943c28719",
-                "reference": "6ed419c3267d56e6bc91abea2268926943c28719",
+                "url": "https://api.github.com/repos/spryker/security-gui/zipball/bee29d901c596035d6a5b7001a02034c61c2a14e",
+                "reference": "bee29d901c596035d6a5b7001a02034c61c2a14e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/messenger": "^3.0.0",
-                "spryker/security": "^1.3.0",
+                "spryker/security": "^1.8.0",
                 "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-gui-extension": "^1.2.0",
@@ -52502,7 +52358,6 @@
                 "spryker/validator": "*"
             },
             "suggest": {
-                "spryker/container": "Add this module to use the Container.",
                 "spryker/router": "You need to install this module when you want to use the RouterExtension interfaces."
             },
             "type": "library",
@@ -52522,9 +52377,9 @@
             ],
             "description": "SecurityGui module",
             "support": {
-                "source": "https://github.com/spryker/security-gui/tree/1.5.0"
+                "source": "https://github.com/spryker/security-gui/tree/1.6.0"
             },
-            "time": "2023-11-24T22:16:26+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-gui-extension",
@@ -52569,16 +52424,16 @@
         },
         {
             "name": "spryker/security-merchant-portal-gui",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-merchant-portal-gui.git",
-                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e"
+                "reference": "e181b4483c2787dbe28e8f5da6e9fa4cad358668"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/dddee33c56f44783e290d8a4d006202ec52a805e",
-                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e",
+                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/e181b4483c2787dbe28e8f5da6e9fa4cad358668",
+                "reference": "e181b4483c2787dbe28e8f5da6e9fa4cad358668",
                 "shasum": ""
             },
             "require": {
@@ -52587,7 +52442,7 @@
                 "spryker/kernel": "^3.33.0",
                 "spryker/merchant-user": "^1.0.0",
                 "spryker/messenger": "^3.0.0",
-                "spryker/security": "^1.5.0",
+                "spryker/security": "^1.8.0",
                 "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-merchant-portal-gui-extension": "^1.0.0",
@@ -52612,9 +52467,6 @@
                 "spryker/user": "*",
                 "spryker/validator": "*"
             },
-            "suggest": {
-                "spryker/container": "Add this module when you want to use the Container."
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -52632,26 +52484,26 @@
             ],
             "description": "SecurityMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.2.0"
+                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.3.0"
             },
-            "time": "2023-11-24T22:16:26+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-merchant-portal-gui-extension",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-merchant-portal-gui-extension.git",
-                "reference": "6313427968cb4e41dbd8e81e19730ce7a7bb1ec5"
+                "reference": "2e2511db3a7f60206d738e403a56c829c66f4277"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui-extension/zipball/6313427968cb4e41dbd8e81e19730ce7a7bb1ec5",
-                "reference": "6313427968cb4e41dbd8e81e19730ce7a7bb1ec5",
+                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui-extension/zipball/2e2511db3a7f60206d738e403a56c829c66f4277",
+                "reference": "2e2511db3a7f60206d738e403a56c829c66f4277",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -52673,26 +52525,26 @@
             ],
             "description": "SecurityMerchantPortalGuiExtension module",
             "support": {
-                "source": "https://github.com/spryker/security-merchant-portal-gui-extension/tree/1.0.0"
+                "source": "https://github.com/spryker/security-merchant-portal-gui-extension/tree/1.1.0"
             },
-            "time": "2022-08-16T17:27:05+00:00"
+            "time": "2024-02-06T10:56:40+00:00"
         },
         {
             "name": "spryker/security-oauth-user",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-oauth-user.git",
-                "reference": "01d9a998e3c6c09ac75361ccc4e442fda1da5699"
+                "reference": "becf10b85a6e7b53284b115580b980962b1e0e68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-oauth-user/zipball/01d9a998e3c6c09ac75361ccc4e442fda1da5699",
-                "reference": "01d9a998e3c6c09ac75361ccc4e442fda1da5699",
+                "url": "https://api.github.com/repos/spryker/security-oauth-user/zipball/becf10b85a6e7b53284b115580b980962b1e0e68",
+                "reference": "becf10b85a6e7b53284b115580b980962b1e0e68",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl": "^3.4.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/messenger": "^3.0.0",
@@ -52714,9 +52566,6 @@
                 "spryker/session": "*",
                 "spryker/testify": "*"
             },
-            "suggest": {
-                "spryker/container": "Add this module to use the Container."
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -52734,9 +52583,9 @@
             ],
             "description": "SecurityOauthUser module",
             "support": {
-                "source": "https://github.com/spryker/security-oauth-user/tree/1.3.0"
+                "source": "https://github.com/spryker/security-oauth-user/tree/1.4.0"
             },
-            "time": "2023-03-03T10:26:17+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/security-oauth-user-extension",
@@ -52781,24 +52630,25 @@
         },
         {
             "name": "spryker/security-system-user",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-system-user.git",
-                "reference": "a30d66d05108c3dac8c785e5b42fcdc53f33caf9"
+                "reference": "65a1cee5a9f89f4b2f270a917071288e2bc8df3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-system-user/zipball/a30d66d05108c3dac8c785e5b42fcdc53f33caf9",
-                "reference": "a30d66d05108c3dac8c785e5b42fcdc53f33caf9",
+                "url": "https://api.github.com/repos/spryker/security-system-user/zipball/65a1cee5a9f89f4b2f270a917071288e2bc8df3f",
+                "reference": "65a1cee5a9f89f4b2f270a917071288e2bc8df3f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.33.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/session-redis-extension": "^1.0.0",
                 "spryker/symfony": "^3.5.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/user": "^3.0.0"
             },
             "require-dev": {
@@ -52808,10 +52658,8 @@
                 "spryker/event-dispatcher": "*",
                 "spryker/router": "*",
                 "spryker/security": "*",
+                "spryker/session": "*",
                 "spryker/testify": "*"
-            },
-            "suggest": {
-                "spryker/container": "Add this module when you want to use the Container."
             },
             "type": "library",
             "extra": {
@@ -52830,9 +52678,9 @@
             ],
             "description": "SecuritySystemUser module",
             "support": {
-                "source": "https://github.com/spryker/security-system-user/tree/1.0.0"
+                "source": "https://github.com/spryker/security-system-user/tree/1.1.0"
             },
-            "time": "2021-08-11T11:07:06+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/sequence-number",
@@ -53655,20 +53503,21 @@
         },
         {
             "name": "spryker/session-user-validation",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/session-user-validation.git",
-                "reference": "105d9a5c863a217fd78d524d484def5cfb8c795d"
+                "reference": "d8aa137b9479f6f9c2e4fa7234c1a3effa914b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/session-user-validation/zipball/105d9a5c863a217fd78d524d484def5cfb8c795d",
-                "reference": "105d9a5c863a217fd78d524d484def5cfb8c795d",
+                "url": "https://api.github.com/repos/spryker/session-user-validation/zipball/d8aa137b9479f6f9c2e4fa7234c1a3effa914b94",
+                "reference": "d8aa137b9479f6f9c2e4fa7234c1a3effa914b94",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
+                "spryker/container": "^1.4.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/session-user-validation-extension": "^1.0.0",
@@ -53677,12 +53526,10 @@
                 "spryker/user": "^3.17.0"
             },
             "require-dev": {
-                "spryker/code-sniffer": "*",
-                "spryker/container": "*"
+                "spryker/code-sniffer": "*"
             },
             "suggest": {
-                "spryker/container": "Add this module if you want to use security plugins.N",
-                "spryker/event-dispatcher": "Add this module if you want to use security plugins.N"
+                "spryker/event-dispatcher": "Add this module if you want to use security plugins."
             },
             "type": "library",
             "extra": {
@@ -53701,9 +53548,9 @@
             ],
             "description": "SessionUserValidation module",
             "support": {
-                "source": "https://github.com/spryker/session-user-validation/tree/1.3.0"
+                "source": "https://github.com/spryker/session-user-validation/tree/1.4.0"
             },
-            "time": "2023-09-07T10:42:07+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/session-user-validation-extension",
@@ -53843,20 +53690,20 @@
         },
         {
             "name": "spryker/shipment",
-            "version": "8.18.0",
+            "version": "8.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment.git",
-                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52"
+                "reference": "044acd9756048a41975cb7751f438e198cf92774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment/zipball/8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
-                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
+                "url": "https://api.github.com/repos/spryker/shipment/zipball/044acd9756048a41975cb7751f438e198cf92774",
+                "reference": "044acd9756048a41975cb7751f438e198cf92774",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.9.0",
                 "spryker/calculation-extension": "^1.0.0",
@@ -53872,7 +53719,7 @@
                 "spryker/sales-extension": "^1.6.0",
                 "spryker/session": "^3.0.0 || ^4.0.0",
                 "spryker/shipment-extension": "^1.2.0",
-                "spryker/store": "^1.4.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax": "^5.0.0",
                 "spryker/transfer": "^3.27.0",
@@ -53909,9 +53756,9 @@
             ],
             "description": "Shipment module",
             "support": {
-                "source": "https://github.com/spryker/shipment/tree/8.18.0"
+                "source": "https://github.com/spryker/shipment/tree/8.22.0"
             },
-            "time": "2023-10-25T07:06:24+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/shipment-cart-connector",
@@ -55258,20 +55105,20 @@
         },
         {
             "name": "spryker/stock",
-            "version": "8.8.3",
+            "version": "8.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/stock.git",
-                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138"
+                "reference": "bcb4a6d4c16d675509a6b50c62e181151f6698cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/stock/zipball/5261ab0f27009e6e3bae8d9edc44b83f52353138",
-                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138",
+                "url": "https://api.github.com/repos/spryker/stock/zipball/bcb4a6d4c16d675509a6b50c62e181151f6698cf",
+                "reference": "bcb4a6d4c16d675509a6b50c62e181151f6698cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/decimal-object": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -55306,9 +55153,9 @@
             ],
             "description": "Stock module",
             "support": {
-                "source": "https://github.com/spryker/stock/tree/8.8.3"
+                "source": "https://github.com/spryker/stock/tree/8.9.0"
             },
-            "time": "2023-07-25T12:51:44+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/stock-address",
@@ -55545,16 +55392,16 @@
         },
         {
             "name": "spryker/storage",
-            "version": "3.22.0",
+            "version": "3.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/storage.git",
-                "reference": "31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60"
+                "reference": "66e9b13ebd6f6a606ff03618761abaffc0116b21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/storage/zipball/31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60",
-                "reference": "31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60",
+                "url": "https://api.github.com/repos/spryker/storage/zipball/66e9b13ebd6f6a606ff03618761abaffc0116b21",
+                "reference": "66e9b13ebd6f6a606ff03618761abaffc0116b21",
                 "shasum": ""
             },
             "require": {
@@ -55605,9 +55452,9 @@
             ],
             "description": "Storage module",
             "support": {
-                "source": "https://github.com/spryker/storage/tree/3.22.0"
+                "source": "https://github.com/spryker/storage/tree/3.22.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/storage-database",
@@ -55842,16 +55689,16 @@
         },
         {
             "name": "spryker/store",
-            "version": "1.24.0",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/store.git",
-                "reference": "e43d709512f8dfc705205c7bfff918d46166e8ed"
+                "reference": "4039f0b440f52c8fd56def8bc7e3774834af6c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/store/zipball/e43d709512f8dfc705205c7bfff918d46166e8ed",
-                "reference": "e43d709512f8dfc705205c7bfff918d46166e8ed",
+                "url": "https://api.github.com/repos/spryker/store/zipball/4039f0b440f52c8fd56def8bc7e3774834af6c9e",
+                "reference": "4039f0b440f52c8fd56def8bc7e3774834af6c9e",
                 "shasum": ""
             },
             "require": {
@@ -55873,9 +55720,12 @@
             "require-dev": {
                 "spryker/code-sniffer": "*",
                 "spryker/container": "*",
+                "spryker/country": "*",
+                "spryker/currency": "*",
                 "spryker/locale": "*",
                 "spryker/propel": "*",
                 "spryker/quote": "*",
+                "spryker/store-storage": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -55892,6 +55742,7 @@
             "autoload": {
                 "psr-4": {
                     "Spryker\\": "src/Spryker/",
+                    "SprykerTest\\Zed\\Store\\Helper\\": "tests/SprykerTest/Zed/Store/_support/Helper/",
                     "SprykerTest\\Shared\\Store\\Helper\\": "tests/SprykerTest/Shared/Store/_support/Helper/"
                 }
             },
@@ -55901,9 +55752,9 @@
             ],
             "description": "Store module",
             "support": {
-                "source": "https://github.com/spryker/store/tree/1.24.0"
+                "source": "https://github.com/spryker/store/tree/1.27.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-06-18T09:53:39+00:00"
         },
         {
             "name": "spryker/store-context-gui",
@@ -56364,16 +56215,16 @@
         },
         {
             "name": "spryker/symfony",
-            "version": "3.14.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/symfony.git",
-                "reference": "5310f7b7af7de82957a65c637d872e5542e5e702"
+                "reference": "9eee920faa74a702919def1720196456e085ac5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/symfony/zipball/5310f7b7af7de82957a65c637d872e5542e5e702",
-                "reference": "5310f7b7af7de82957a65c637d872e5542e5e702",
+                "url": "https://api.github.com/repos/spryker/symfony/zipball/9eee920faa74a702919def1720196456e085ac5a",
+                "reference": "9eee920faa74a702919def1720196456e085ac5a",
                 "shasum": ""
             },
             "require": {
@@ -56397,10 +56248,10 @@
                 "symfony/process": "^5.4.0 || ^6.0.0",
                 "symfony/property-access": "^5.4.0 || ^6.0.0",
                 "symfony/routing": "^5.1.0 || ^6.0.0",
-                "symfony/security-core": "^5.4.21",
+                "symfony/security-core": "^5.4.21 || ^6.0.0",
                 "symfony/security-csrf": "^5.3.0 || ^6.0.0",
-                "symfony/security-guard": "^5.4.21",
-                "symfony/security-http": "^5.4.31",
+                "symfony/security-guard": "^5.4.0",
+                "symfony/security-http": "^5.4.31 || ^6.0.0",
                 "symfony/serializer": "^5.0.9 || ^6.0.0",
                 "symfony/stopwatch": "^5.0.9 || ^6.0.0",
                 "symfony/translation": "^5.0.9 || ^6.0.0",
@@ -56431,9 +56282,9 @@
             ],
             "description": "Symfony module",
             "support": {
-                "source": "https://github.com/spryker/symfony/tree/3.14.0"
+                "source": "https://github.com/spryker/symfony/tree/3.15.0"
             },
-            "time": "2023-11-13T12:52:16+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/symfony-mailer",
@@ -56668,16 +56519,16 @@
         },
         {
             "name": "spryker/tax",
-            "version": "5.15.0",
+            "version": "5.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/tax.git",
-                "reference": "114523d37cca93821711d4ddd9700ee338a111c8"
+                "reference": "14775f145e29ef6019771409be86103133269450"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/tax/zipball/114523d37cca93821711d4ddd9700ee338a111c8",
-                "reference": "114523d37cca93821711d4ddd9700ee338a111c8",
+                "url": "https://api.github.com/repos/spryker/tax/zipball/14775f145e29ef6019771409be86103133269450",
+                "reference": "14775f145e29ef6019771409be86103133269450",
                 "shasum": ""
             },
             "require": {
@@ -56726,9 +56577,9 @@
             ],
             "description": "Tax module",
             "support": {
-                "source": "https://github.com/spryker/tax/tree/5.15.0"
+                "source": "https://github.com/spryker/tax/tree/5.16.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/tax-app",
@@ -57111,16 +56962,16 @@
         },
         {
             "name": "spryker/touch",
-            "version": "4.7.0",
+            "version": "4.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/touch.git",
-                "reference": "93f921f5acbe1651edcc4e7cff6e93f23febe78f"
+                "reference": "7b3885f40a188ce40dd64da5f243460603b0d353"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/touch/zipball/93f921f5acbe1651edcc4e7cff6e93f23febe78f",
-                "reference": "93f921f5acbe1651edcc4e7cff6e93f23febe78f",
+                "url": "https://api.github.com/repos/spryker/touch/zipball/7b3885f40a188ce40dd64da5f243460603b0d353",
+                "reference": "7b3885f40a188ce40dd64da5f243460603b0d353",
                 "shasum": ""
             },
             "require": {
@@ -57155,22 +57006,22 @@
             ],
             "description": "Touch module",
             "support": {
-                "source": "https://github.com/spryker/touch/tree/4.7.0"
+                "source": "https://github.com/spryker/touch/tree/4.7.1"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/transfer",
-            "version": "3.34.0",
+            "version": "3.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/transfer.git",
-                "reference": "dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b"
+                "reference": "b3df867764830174fa8bf48ebe1a919f100b44ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/transfer/zipball/dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b",
-                "reference": "dfabe1a4dc33b713cf2487cf42f95d6d2f8d525b",
+                "url": "https://api.github.com/repos/spryker/transfer/zipball/b3df867764830174fa8bf48ebe1a919f100b44ee",
+                "reference": "b3df867764830174fa8bf48ebe1a919f100b44ee",
                 "shasum": ""
             },
             "require": {
@@ -57206,22 +57057,22 @@
             ],
             "description": "Transfer module",
             "support": {
-                "source": "https://github.com/spryker/transfer/tree/3.34.0"
+                "source": "https://github.com/spryker/transfer/tree/3.36.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-04-12T11:26:30+00:00"
         },
         {
             "name": "spryker/translator",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/translator.git",
-                "reference": "717c2811468591dac1ba2c27c7a93d0809ae5fcb"
+                "reference": "fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/translator/zipball/717c2811468591dac1ba2c27c7a93d0809ae5fcb",
-                "reference": "717c2811468591dac1ba2c27c7a93d0809ae5fcb",
+                "url": "https://api.github.com/repos/spryker/translator/zipball/fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769",
+                "reference": "fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769",
                 "shasum": ""
             },
             "require": {
@@ -57242,6 +57093,8 @@
                 "spryker/container": "*",
                 "spryker/installer": "*",
                 "spryker/silex": "^2.2.0",
+                "spryker/storage": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -57265,9 +57118,9 @@
             ],
             "description": "Translator module",
             "support": {
-                "source": "https://github.com/spryker/translator/tree/1.12.0"
+                "source": "https://github.com/spryker/translator/tree/1.13.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-29T15:41:47+00:00"
         },
         {
             "name": "spryker/translator-extension",
@@ -57316,16 +57169,16 @@
         },
         {
             "name": "spryker/twig",
-            "version": "3.19.0",
+            "version": "3.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/twig.git",
-                "reference": "edb5f3254ec226949b7346d243818053af6d7cdc"
+                "reference": "dfb97af12ac406c191f7a8a0e440bd43d967bf31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/twig/zipball/edb5f3254ec226949b7346d243818053af6d7cdc",
-                "reference": "edb5f3254ec226949b7346d243818053af6d7cdc",
+                "url": "https://api.github.com/repos/spryker/twig/zipball/dfb97af12ac406c191f7a8a0e440bd43d967bf31",
+                "reference": "dfb97af12ac406c191f7a8a0e440bd43d967bf31",
                 "shasum": ""
             },
             "require": {
@@ -57338,7 +57191,7 @@
                 "spryker/symfony": "^3.0.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-text": "^1.0.0",
-                "twig/twig": "^2.15.3 || ^3.4.3"
+                "twig/twig": "^2.15.3 || >=3.4.3 <3.9.0"
             },
             "require-dev": {
                 "spryker/application": "*",
@@ -57370,9 +57223,9 @@
             ],
             "description": "Twig module",
             "support": {
-                "source": "https://github.com/spryker/twig/tree/3.19.0"
+                "source": "https://github.com/spryker/twig/tree/3.23.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2024-07-10T14:18:07+00:00"
         },
         {
             "name": "spryker/twig-extension",
@@ -57472,20 +57325,20 @@
         },
         {
             "name": "spryker/url",
-            "version": "3.12.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/url.git",
-                "reference": "c2b6dfb9739f3a52acc46dad05e99706594c8154"
+                "reference": "6e9eee94a0feaee832c33830f84226bf45bbe6b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/url/zipball/c2b6dfb9739f3a52acc46dad05e99706594c8154",
-                "reference": "c2b6dfb9739f3a52acc46dad05e99706594c8154",
+                "url": "https://api.github.com/repos/spryker/url/zipball/6e9eee94a0feaee832c33830f84226bf45bbe6b5",
+                "reference": "6e9eee94a0feaee832c33830f84226bf45bbe6b5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
@@ -57526,9 +57379,9 @@
             ],
             "description": "Url module",
             "support": {
-                "source": "https://github.com/spryker/url/tree/3.12.0"
+                "source": "https://github.com/spryker/url/tree/3.14.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2024-05-06T12:15:28+00:00"
         },
         {
             "name": "spryker/url-storage",
@@ -57683,16 +57536,16 @@
         },
         {
             "name": "spryker/user",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user.git",
-                "reference": "a9e2d9f5f30a193da6f2b485e0a95c143125db23"
+                "reference": "5b351d23318437a8fb7223792183798861461049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user/zipball/a9e2d9f5f30a193da6f2b485e0a95c143125db23",
-                "reference": "a9e2d9f5f30a193da6f2b485e0a95c143125db23",
+                "url": "https://api.github.com/repos/spryker/user/zipball/5b351d23318437a8fb7223792183798861461049",
+                "reference": "5b351d23318437a8fb7223792183798861461049",
                 "shasum": ""
             },
             "require": {
@@ -57727,7 +57580,6 @@
                 "spryker/zed-navigation": "*"
             },
             "suggest": {
-                "spryker/container": "If you want to use UserTwigPlugin.",
                 "spryker/installer": "If you want to use Installer plugin.",
                 "spryker/silex": "If you want to use ServiceProvider.",
                 "spryker/twig": "Use this module when using plugins that need Twig dependencies."
@@ -57750,26 +57602,26 @@
             ],
             "description": "User module",
             "support": {
-                "source": "https://github.com/spryker/user/tree/3.19.0"
+                "source": "https://github.com/spryker/user/tree/3.20.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-12-21T16:51:01+00:00"
         },
         {
             "name": "spryker/user-extension",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user-extension.git",
-                "reference": "cde218f31419476214a34e4861ff8cc7ec952b61"
+                "reference": "14b45944295bdf2868487fa17c41812d013ea796"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-extension/zipball/cde218f31419476214a34e4861ff8cc7ec952b61",
-                "reference": "cde218f31419476214a34e4861ff8cc7ec952b61",
+                "url": "https://api.github.com/repos/spryker/user-extension/zipball/14b45944295bdf2868487fa17c41812d013ea796",
+                "reference": "14b45944295bdf2868487fa17c41812d013ea796",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
@@ -57798,9 +57650,9 @@
             ],
             "description": "UserExtension module",
             "support": {
-                "source": "https://github.com/spryker/user-extension/tree/1.2.0"
+                "source": "https://github.com/spryker/user-extension/tree/1.3.0"
             },
-            "time": "2023-02-08T12:23:08+00:00"
+            "time": "2024-02-06T10:56:40+00:00"
         },
         {
             "name": "spryker/user-locale",
@@ -58281,20 +58133,20 @@
         },
         {
             "name": "spryker/util-date-time",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-date-time.git",
-                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962"
+                "reference": "06b990eb76bd16ea70ef8f534b8f6e2a5fface04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/01a1c0ca748c9d04faaa2dc404a2232132157962",
-                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962",
+                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/06b990eb76bd16ea70ef8f534b8f6e2a5fface04",
+                "reference": "06b990eb76bd16ea70ef8f534b8f6e2a5fface04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/config": "^3.0.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/twig": "^3.1.0"
@@ -58326,9 +58178,9 @@
             ],
             "description": "UtilDateTime module",
             "support": {
-                "source": "https://github.com/spryker/util-date-time/tree/1.4.1"
+                "source": "https://github.com/spryker/util-date-time/tree/1.5.0"
             },
-            "time": "2023-07-27T15:38:05+00:00"
+            "time": "2024-03-27T10:11:29+00:00"
         },
         {
             "name": "spryker/util-encoding",
@@ -58681,20 +58533,20 @@
         },
         {
             "name": "spryker/util-text",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-text.git",
-                "reference": "715d1cb04b5222445f331564faff7dd934a71166"
+                "reference": "9d43926ccbbe4b6fdaf050c7a70a0cac2708382f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-text/zipball/715d1cb04b5222445f331564faff7dd934a71166",
-                "reference": "715d1cb04b5222445f331564faff7dd934a71166",
+                "url": "https://api.github.com/repos/spryker/util-text/zipball/9d43926ccbbe4b6fdaf050c7a70a0cac2708382f",
+                "reference": "9d43926ccbbe4b6fdaf050c7a70a0cac2708382f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0"
             },
             "require-dev": {
@@ -58720,9 +58572,9 @@
             ],
             "description": "UtilText module",
             "support": {
-                "source": "https://github.com/spryker/util-text/tree/1.5.1"
+                "source": "https://github.com/spryker/util-text/tree/1.6.0"
             },
-            "time": "2022-12-01T11:40:47+00:00"
+            "time": "2023-12-06T14:05:47+00:00"
         },
         {
             "name": "spryker/util-uuid-generator",
@@ -59832,20 +59684,20 @@
         },
         {
             "name": "spryker/zed-request",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-request.git",
-                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a"
+                "reference": "369d1a325af4963c712ce62a3524bee2f5cbe756"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-request/zipball/b06b5e843f8b3406436b0567dc6dd6581725fa1a",
-                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a",
+                "url": "https://api.github.com/repos/spryker/zed-request/zipball/369d1a325af4963c712ce62a3524bee2f5cbe756",
+                "reference": "369d1a325af4963c712ce62a3524bee2f5cbe756",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/http-message": "^1.0.0",
                 "spryker/application-extension": "^1.1.0",
                 "spryker/config": "^3.0.0",
@@ -59897,9 +59749,9 @@
             ],
             "description": "ZedRequest module",
             "support": {
-                "source": "https://github.com/spryker/zed-request/tree/3.20.0"
+                "source": "https://github.com/spryker/zed-request/tree/3.21.0"
             },
-            "time": "2023-10-19T09:26:16+00:00"
+            "time": "2024-04-16T13:44:16+00:00"
         },
         {
             "name": "spryker/zed-request-extension",
@@ -59948,20 +59800,20 @@
         },
         {
             "name": "spryker/zed-ui",
-            "version": "2.2.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-ui.git",
-                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8"
+                "reference": "5fa641a7255d8f51f9a5f9c805abb9e382e0bfec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-ui/zipball/68286df3a6d3006369403a369ca050b8dd28cdf8",
-                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8",
+                "url": "https://api.github.com/repos/spryker/zed-ui/zipball/5fa641a7255d8f51f9a5f9c805abb9e382e0bfec",
+                "reference": "5fa641a7255d8f51f9a5f9c805abb9e382e0bfec",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/symfony": "^3.0.0",
@@ -59997,9 +59849,9 @@
             ],
             "description": "ZedUi module",
             "support": {
-                "source": "https://github.com/spryker/zed-ui/tree/2.2.0"
+                "source": "https://github.com/spryker/zed-ui/tree/2.4.1"
             },
-            "time": "2023-09-12T13:38:42+00:00"
+            "time": "2024-03-27T10:11:29+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -60079,40 +59931,34 @@
         },
         {
             "name": "symfony-cmf/routing",
-            "version": "3.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/Routing.git",
-                "reference": "59a811cc2fa4825b1ff87f5a0d83778148f877db"
+                "reference": "4d6e40f8f91f5729e00e5a023640eb13fb359cbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/Routing/zipball/59a811cc2fa4825b1ff87f5a0d83778148f877db",
-                "reference": "59a811cc2fa4825b1ff87f5a0d83778148f877db",
+                "url": "https://api.github.com/repos/symfony-cmf/Routing/zipball/4d6e40f8f91f5729e00e5a023640eb13fb359cbd",
+                "reference": "4d6e40f8f91f5729e00e5a023640eb13fb359cbd",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "symfony/http-kernel": "^6.0",
-                "symfony/routing": "^6.0"
+                "symfony/http-kernel": "^6.0 || ^7.0",
+                "symfony/routing": "^6.0 || ^7.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.5",
-                "symfony/config": "^6.0",
-                "symfony/dependency-injection": "^6.0",
-                "symfony/event-dispatcher": "^6.0",
-                "symfony/phpunit-bridge": "^6.0"
+                "symfony/config": "^6.0 || ^7.0",
+                "symfony/dependency-injection": "^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^7.0.3"
             },
             "suggest": {
                 "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version ^6.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Cmf\\Component\\Routing\\": "src/"
@@ -60136,9 +59982,9 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony-cmf/Routing/issues",
-                "source": "https://github.com/symfony-cmf/Routing/tree/3.0.1"
+                "source": "https://github.com/symfony-cmf/Routing/tree/3.0.3"
             },
-            "time": "2022-07-04T07:08:15+00:00"
+            "time": "2024-02-19T02:00:24+00:00"
         },
         {
             "name": "symfony/amazon-sqs-messenger",
@@ -60215,194 +60061,23 @@
             "time": "2023-03-10T10:08:00+00:00"
         },
         {
-            "name": "symfony/cache",
-            "version": "v6.3.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "84aff8d948d6292d2b5a01ac622760be44dddc72"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/84aff8d948d6292d2b5a01ac622760be44dddc72",
-                "reference": "84aff8d948d6292d2b5a01ac622760be44dddc72",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/cache": "^2.0|^3.0",
-                "psr/log": "^1.1|^2|^3",
-                "symfony/cache-contracts": "^2.5|^3",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/var-exporter": "^6.3.6"
-            },
-            "conflict": {
-                "doctrine/dbal": "<2.13.1",
-                "symfony/dependency-injection": "<5.4",
-                "symfony/http-kernel": "<5.4",
-                "symfony/var-dumper": "<5.4"
-            },
-            "provide": {
-                "psr/cache-implementation": "2.0|3.0",
-                "psr/simple-cache-implementation": "1.0|2.0|3.0",
-                "symfony/cache-implementation": "1.1|2.0|3.0"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/dbal": "^2.13.1|^3|^4",
-                "predis/predis": "^1.1|^2.0",
-                "psr/simple-cache": "^1.0|^2.0|^3.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/messenger": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Cache\\": ""
-                },
-                "classmap": [
-                    "Traits/ValueWrapper.php"
-                ],
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "caching",
-                "psr6"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.3.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-17T14:44:58+00:00"
-        },
-        {
-            "name": "symfony/cache-contracts",
-            "version": "v3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "ad945640ccc0ae6e208bcea7d7de4b39b569896b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/ad945640ccc0ae6e208bcea7d7de4b39b569896b",
-                "reference": "ad945640ccc0ae6e208bcea7d7de4b39b569896b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/cache": "^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Cache\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to caching",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
             "name": "symfony/clock",
-            "version": "v6.3.4",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "a74086d3db70d0f06ffd84480daa556248706e98"
+                "reference": "7a4840efd17135cbd547e41ec49fb910ed4f8b98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/a74086d3db70d0f06ffd84480daa556248706e98",
-                "reference": "a74086d3db70d0f06ffd84480daa556248706e98",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/7a4840efd17135cbd547e41ec49fb910ed4f8b98",
+                "reference": "7a4840efd17135cbd547e41ec49fb910ed4f8b98",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/clock": "^1.0"
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -60441,7 +60116,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v6.3.4"
+                "source": "https://github.com/symfony/clock/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -60457,26 +60132,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-31T11:35:03+00:00"
+            "time": "2024-05-31T14:51:39+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v6.3.2",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b47ca238b03e7b0d7880ffd1cf06e8d637ca1467"
+                "reference": "12e7e52515ce37191b193cf3365903c4f3951e35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b47ca238b03e7b0d7880ffd1cf06e8d637ca1467",
-                "reference": "b47ca238b03e7b0d7880ffd1cf06e8d637ca1467",
+                "url": "https://api.github.com/repos/symfony/config/zipball/12e7e52515ce37191b193cf3365903c4f3951e35",
+                "reference": "12e7e52515ce37191b193cf3365903c4f3951e35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -60484,11 +60159,11 @@
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/messenger": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -60516,7 +60191,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.3.2"
+                "source": "https://github.com/symfony/config/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -60532,20 +60207,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T20:22:16+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.3.4",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6"
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/eca495f2ee845130855ddf1cf18460c38966c8b6",
-                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
                 "shasum": ""
             },
             "require": {
@@ -60553,7 +60228,7 @@
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<5.4",
@@ -60567,12 +60242,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -60606,7 +60285,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.3.4"
+                "source": "https://github.com/symfony/console/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -60622,7 +60301,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-16T10:10:12+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/debug",
@@ -60694,98 +60373,17 @@
             "time": "2022-07-28T16:29:46+00:00"
         },
         {
-            "name": "symfony/dependency-injection",
-            "version": "v6.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2ed62b3bf98346e1f45529a7b6be2196739bb993",
-                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/service-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.2.10"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2",
-                "symfony/config": "<6.1",
-                "symfony/finder": "<5.4",
-                "symfony/proxy-manager-bridge": "<6.3",
-                "symfony/yaml": "<5.4"
-            },
-            "provide": {
-                "psr/container-implementation": "1.1|2.0",
-                "symfony/service-implementation": "1.1|2.0|3.0"
-            },
-            "require-dev": {
-                "symfony/config": "^6.1",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\DependencyInjection\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.5"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-09-25T16:46:40+00:00"
-        },
-        {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
                 "shasum": ""
             },
             "require": {
@@ -60794,7 +60392,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -60823,7 +60421,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -60839,94 +60437,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/dotenv",
-            "version": "v6.3.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dotenv.git",
-                "reference": "7dfbe2976f3c1b7cfa8fac2212a050bfa9bd7d9e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/7dfbe2976f3c1b7cfa8fac2212a050bfa9bd7d9e",
-                "reference": "7dfbe2976f3c1b7cfa8fac2212a050bfa9bd7d9e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "conflict": {
-                "symfony/console": "<5.4",
-                "symfony/process": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Dotenv\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Registers environment variables from a .env file",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "dotenv",
-                "env",
-                "environment"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.3.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-26T18:15:14+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.3.5",
+            "version": "v6.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "1f69476b64fb47105c06beef757766c376b548c4"
+                "reference": "93a8400a7eaaaf385b2d6f71e30e064baa639629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/1f69476b64fb47105c06beef757766c376b548c4",
-                "reference": "1f69476b64fb47105c06beef757766c376b548c4",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/93a8400a7eaaaf385b2d6f71e30e064baa639629",
+                "reference": "93a8400a7eaaaf385b2d6f71e30e064baa639629",
                 "shasum": ""
             },
             "require": {
@@ -60971,7 +60495,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.3.5"
+                "source": "https://github.com/symfony/error-handler/tree/v6.3.12"
             },
             "funding": [
                 {
@@ -60987,20 +60511,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-12T06:57:20+00:00"
+            "time": "2024-01-23T14:35:58+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.3.2",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "adb01fe097a4ee930db9258a3cc906b5beb5cf2e"
+                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/adb01fe097a4ee930db9258a3cc906b5beb5cf2e",
-                "reference": "adb01fe097a4ee930db9258a3cc906b5beb5cf2e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8d7507f02b06e06815e56bb39aa0128e3806208b",
+                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b",
                 "shasum": ""
             },
             "require": {
@@ -61017,13 +60541,13 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^5.4|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61051,7 +60575,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.3.2"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -61067,20 +60591,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-06T06:56:43+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.3.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
+                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/8f93aec25d41b72493c6ddff14e916177c9efc50",
+                "reference": "8f93aec25d41b72493c6ddff14e916177c9efc50",
                 "shasum": ""
             },
             "require": {
@@ -61090,7 +60614,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -61127,7 +60651,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -61143,26 +60667,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.3.1",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
-                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b51ef8059159330b74a4d52f68e671033c0fe463",
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^5.4|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61190,7 +60717,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -61206,27 +60733,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-01T08:30:39+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.3.5",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4"
+                "reference": "3ef977a43883215d560a2cecb82ec8e62131471c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a1b31d88c0e998168ca7792f222cbecee47428c4",
-                "reference": "a1b31d88c0e998168ca7792f222cbecee47428c4",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3ef977a43883215d560a2cecb82ec8e62131471c",
+                "reference": "3ef977a43883215d560a2cecb82ec8e62131471c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.0"
+                "symfony/filesystem": "^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61254,7 +60781,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.3.5"
+                "source": "https://github.com/symfony/finder/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -61270,96 +60797,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-26T12:56:25+00:00"
-        },
-        {
-            "name": "symfony/flex",
-            "version": "v2.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/flex.git",
-                "reference": "ae6dea68771c5fca9d172e0c0910bdd06199f6f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/ae6dea68771c5fca9d172e0c0910bdd06199f6f4",
-                "reference": "ae6dea68771c5fca9d172e0c0910bdd06199f6f4",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^2.1",
-                "php": ">=8.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.1",
-                "symfony/dotenv": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/phpunit-bridge": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Symfony\\Flex\\Flex"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Flex\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien.potencier@gmail.com"
-                }
-            ],
-            "description": "Composer plugin for Symfony",
-            "support": {
-                "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v2.4.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-30T18:35:17+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/form",
-            "version": "v6.3.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "e6743d188f168643cb247f65cbad09ddb1dfcfe5"
+                "reference": "196ebc738e59bec2bbf1f49c24cc221b47f77f5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/e6743d188f168643cb247f65cbad09ddb1dfcfe5",
-                "reference": "e6743d188f168643cb247f65cbad09ddb1dfcfe5",
+                "url": "https://api.github.com/repos/symfony/form/zipball/196ebc738e59bec2bbf1f49c24cc221b47f77f5d",
+                "reference": "196ebc738e59bec2bbf1f49c24cc221b47f77f5d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/options-resolver": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/options-resolver": "^5.4|^6.0|^7.0",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-icu": "^1.21",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -61369,26 +60831,26 @@
                 "symfony/error-handler": "<5.4",
                 "symfony/framework-bundle": "<5.4",
                 "symfony/http-kernel": "<5.4",
-                "symfony/translation": "<5.4",
+                "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3|>=7.0,<7.0.3",
                 "symfony/translation-contracts": "<2.5",
                 "symfony/twig-bridge": "<6.3"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0|^2.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/html-sanitizer": "^6.1",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/security-core": "^6.2",
-                "symfony/security-csrf": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/html-sanitizer": "^6.1|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^6.2|^7.0",
+                "symfony/security-csrf": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4.35|~6.3.12|^6.4.3|^7.0.3",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61416,7 +60878,7 @@
             "description": "Allows to easily create, process and reuse HTML forms",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/form/tree/v6.3.7"
+                "source": "https://github.com/symfony/form/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -61432,171 +60894,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:11:45+00:00"
-        },
-        {
-            "name": "symfony/framework-bundle",
-            "version": "v6.3.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "dba20792c726c30d455626eddfb2db008f64085f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/dba20792c726c30d455626eddfb2db008f64085f",
-                "reference": "dba20792c726c30d455626eddfb2db008f64085f",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": ">=2.1",
-                "ext-xml": "*",
-                "php": ">=8.1",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^6.1",
-                "symfony/dependency-injection": "^6.3.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.1",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-foundation": "^6.3",
-                "symfony/http-kernel": "^6.3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/routing": "^5.4|^6.0"
-            },
-            "conflict": {
-                "doctrine/annotations": "<1.13.1",
-                "doctrine/persistence": "<1.3",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/asset": "<5.4",
-                "symfony/clock": "<6.3",
-                "symfony/console": "<5.4",
-                "symfony/dom-crawler": "<6.3",
-                "symfony/dotenv": "<5.4",
-                "symfony/form": "<5.4",
-                "symfony/http-client": "<6.3",
-                "symfony/lock": "<5.4",
-                "symfony/mailer": "<5.4",
-                "symfony/messenger": "<6.3",
-                "symfony/mime": "<6.2",
-                "symfony/property-access": "<5.4",
-                "symfony/property-info": "<5.4",
-                "symfony/security-core": "<5.4",
-                "symfony/security-csrf": "<5.4",
-                "symfony/serializer": "<6.3",
-                "symfony/stopwatch": "<5.4",
-                "symfony/translation": "<6.2.8",
-                "symfony/twig-bridge": "<5.4",
-                "symfony/twig-bundle": "<5.4",
-                "symfony/validator": "<6.3",
-                "symfony/web-profiler-bundle": "<5.4",
-                "symfony/workflow": "<5.4"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^1.13.1|^2",
-                "doctrine/persistence": "^1.3|^2|^3",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/asset": "^5.4|^6.0",
-                "symfony/asset-mapper": "^6.3",
-                "symfony/browser-kit": "^5.4|^6.0",
-                "symfony/clock": "^6.2",
-                "symfony/console": "^5.4.9|^6.0.9",
-                "symfony/css-selector": "^5.4|^6.0",
-                "symfony/dom-crawler": "^6.3",
-                "symfony/dotenv": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/form": "^5.4|^6.0",
-                "symfony/html-sanitizer": "^6.1",
-                "symfony/http-client": "^6.3",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/mailer": "^5.4|^6.0",
-                "symfony/messenger": "^6.3",
-                "symfony/mime": "^6.2",
-                "symfony/notifier": "^5.4|^6.0",
-                "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/rate-limiter": "^5.4|^6.0",
-                "symfony/scheduler": "^6.3",
-                "symfony/security-bundle": "^5.4|^6.0",
-                "symfony/semaphore": "^5.4|^6.0",
-                "symfony/serializer": "^6.3",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/string": "^5.4|^6.0",
-                "symfony/translation": "^6.2.8",
-                "symfony/twig-bundle": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^6.3",
-                "symfony/web-link": "^5.4|^6.0",
-                "symfony/workflow": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0",
-                "twig/twig": "^2.10|^3.0"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bundle\\FrameworkBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.3.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-26T18:15:14+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.3.7",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d"
+                "reference": "6e9db0025db565bcf8f1d46ed734b549e51e6045"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d",
-                "reference": "cd67fcaf4524ec6ae5d9b2d9497682d7ad3ce57d",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/6e9db0025db565bcf8f1d46ed734b549e51e6045",
+                "reference": "6e9db0025db565bcf8f1d46ed734b549e51e6045",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-client-contracts": "^3",
+                "symfony/http-client-contracts": "^3.4.1",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -61614,14 +60932,15 @@
                 "amphp/http-client": "^4.2.1",
                 "amphp/http-tunnel": "^1.0",
                 "amphp/socket": "^1.1",
-                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/promises": "^1.4|^2.0",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0"
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61652,7 +60971,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.3.7"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -61668,20 +60987,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-29T12:41:36+00:00"
+            "time": "2024-06-28T07:59:05+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.3.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "3b66325d0176b4ec826bffab57c9037d759c31fb"
+                "reference": "20414d96f391677bf80078aa55baece78b82647d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/3b66325d0176b4ec826bffab57c9037d759c31fb",
-                "reference": "3b66325d0176b4ec826bffab57c9037d759c31fb",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/20414d96f391677bf80078aa55baece78b82647d",
+                "reference": "20414d96f391677bf80078aa55baece78b82647d",
                 "shasum": ""
             },
             "require": {
@@ -61690,7 +61009,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -61730,7 +61049,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -61746,20 +61065,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.3.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "59d1837d5d992d16c2628cd0d6b76acf8d69b33e"
+                "reference": "27de8cc95e11db7a50b027e71caaab9024545947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/59d1837d5d992d16c2628cd0d6b76acf8d69b33e",
-                "reference": "59d1837d5d992d16c2628cd0d6b76acf8d69b33e",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/27de8cc95e11db7a50b027e71caaab9024545947",
+                "reference": "27de8cc95e11db7a50b027e71caaab9024545947",
                 "shasum": ""
             },
             "require": {
@@ -61774,12 +61093,12 @@
             "require-dev": {
                 "doctrine/dbal": "^2.13.1|^3|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.3",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/rate-limiter": "^5.2|^6.0"
+                "symfony/cache": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61807,7 +61126,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.3.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -61823,7 +61142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:55:27+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -61940,25 +61259,25 @@
         },
         {
             "name": "symfony/intl",
-            "version": "v6.3.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "4cc98c05f2c55150a6aa5b3e20667f7a6d06cca9"
+                "reference": "50265cdcf5a44bec3fcf487b5d0015aece91d1eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/4cc98c05f2c55150a6aa5b3e20667f7a6d06cca9",
-                "reference": "4cc98c05f2c55150a6aa5b3e20667f7a6d06cca9",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/50265cdcf5a44bec3fcf487b5d0015aece91d1eb",
+                "reference": "50265cdcf5a44bec3fcf487b5d0015aece91d1eb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -61966,7 +61285,8 @@
                     "Symfony\\Component\\Intl\\": ""
                 },
                 "exclude-from-classmap": [
-                    "/Tests/"
+                    "/Tests/",
+                    "/Resources/data/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -62002,7 +61322,7 @@
                 "localization"
             ],
             "support": {
-                "source": "https://github.com/symfony/intl/tree/v6.3.7"
+                "source": "https://github.com/symfony/intl/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -62018,7 +61338,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:11:45+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -62098,22 +61418,22 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v6.3.7",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "a0a8860ca625116c474c9c1f5570bd7ec752c599"
+                "reference": "c211861f5f84860b9663c43dcd440ac8bcb1d250"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/a0a8860ca625116c474c9c1f5570bd7ec752c599",
-                "reference": "a0a8860ca625116c474c9c1f5570bd7ec752c599",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/c211861f5f84860b9663c43dcd440ac8bcb1d250",
+                "reference": "c211861f5f84860b9663c43dcd440ac8bcb1d250",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/clock": "^6.3",
+                "symfony/clock": "^6.3|^7.0",
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -62126,18 +61446,18 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/console": "^6.3",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/rate-limiter": "^5.4|^6.0",
-                "symfony/routing": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0",
+                "symfony/console": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -62165,7 +61485,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v6.3.7"
+                "source": "https://github.com/symfony/messenger/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -62181,20 +61501,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-26T18:15:14+00:00"
+            "time": "2024-06-24T14:04:31+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.3.5",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "d5179eedf1cb2946dbd760475ebf05c251ef6a6e"
+                "reference": "7d048964877324debdcb4e0549becfa064a20d43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/d5179eedf1cb2946dbd760475ebf05c251ef6a6e",
-                "reference": "d5179eedf1cb2946dbd760475ebf05c251ef6a6e",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7d048964877324debdcb4e0549becfa064a20d43",
+                "reference": "7d048964877324debdcb4e0549becfa064a20d43",
                 "shasum": ""
             },
             "require": {
@@ -62208,16 +61528,17 @@
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/mailer": "<5.4",
-                "symfony/serializer": "<6.2.13|>=6.3,<6.3.2"
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/serializer": "~6.2.13|^6.3.2"
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.4|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4.3|^7.0.3"
             },
             "type": "library",
             "autoload": {
@@ -62249,7 +61570,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.3.5"
+                "source": "https://github.com/symfony/mime/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -62265,185 +61586,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-29T06:59:36+00:00"
-        },
-        {
-            "name": "symfony/monolog-bridge",
-            "version": "v5.4.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/34be6f0695e4187dbb832a05905fb4c6581ac39a",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a",
-                "shasum": ""
-            },
-            "require": {
-                "monolog/monolog": "^1.25.1|^2",
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2|^3"
-            },
-            "conflict": {
-                "symfony/console": "<4.4",
-                "symfony/http-foundation": "<5.3"
-            },
-            "require-dev": {
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/mailer": "^4.4|^5.0|^6.0",
-                "symfony/messenger": "^4.4|^5.0|^6.0",
-                "symfony/mime": "^4.4|^5.0|^6.0",
-                "symfony/security-core": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings.",
-                "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
-                "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
-            },
-            "type": "symfony-bridge",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bridge\\Monolog\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides integration for Monolog with various Symfony components",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v5.4.22"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-06T21:29:33+00:00"
-        },
-        {
-            "name": "symfony/monolog-bundle",
-            "version": "v3.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "d14cf794d5b63337849d7e30925778ceaed82b34"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/d14cf794d5b63337849d7e30925778ceaed82b34",
-                "reference": "d14cf794d5b63337849d7e30925778ceaed82b34",
-                "shasum": ""
-            },
-            "require": {
-                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-                "php": ">=7.2.5",
-                "symfony/config": "^5.4 || ^6.0 || ^7.0",
-                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-                "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4 || ^6.0 || ^7.0",
-                "symfony/phpunit-bridge": "^6.3 || ^7.0",
-                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bundle\\MonologBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony MonologBundle",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "log",
-                "logging"
-            ],
-            "support": {
-                "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v3.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-11-06T11:28:48+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.3.0",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "a10f19f5198d589d5c33333cffe98dc9820332dd"
+                "reference": "22ab9e9101ab18de37839074f8a1197f55590c1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a10f19f5198d589d5c33333cffe98dc9820332dd",
-                "reference": "a10f19f5198d589d5c33333cffe98dc9820332dd",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/22ab9e9101ab18de37839074f8a1197f55590c1b",
+                "reference": "22ab9e9101ab18de37839074f8a1197f55590c1b",
                 "shasum": ""
             },
             "require": {
@@ -62481,7 +61637,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.3.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -62497,20 +61653,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-12T14:21:09+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/password-hasher",
-            "version": "v6.3.5",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/password-hasher.git",
-                "reference": "278d3a49715073879f75e372ad80b8cfeca949d3"
+                "reference": "90ebbe946e5d64a5fad9ac9427e335045cf2bd31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/278d3a49715073879f75e372ad80b8cfeca949d3",
-                "reference": "278d3a49715073879f75e372ad80b8cfeca949d3",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/90ebbe946e5d64a5fad9ac9427e335045cf2bd31",
+                "reference": "90ebbe946e5d64a5fad9ac9427e335045cf2bd31",
                 "shasum": ""
             },
             "require": {
@@ -62520,8 +61676,8 @@
                 "symfony/security-core": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0",
-                "symfony/security-core": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -62553,7 +61709,7 @@
                 "password"
             ],
             "support": {
-                "source": "https://github.com/symfony/password-hasher/tree/v6.3.5"
+                "source": "https://github.com/symfony/password-hasher/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -62569,20 +61725,179 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-25T17:05:16+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.28.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "875e90aeea2777b6f135677f618529449334a612"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
-                "reference": "875e90aeea2777b6f135677f618529449334a612",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T15:07:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "c027e6a3c6aee334663ec21f5852e89738abc805"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/c027e6a3c6aee334663ec21f5852e89738abc805",
+                "reference": "c027e6a3c6aee334663ec21f5852e89738abc805",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T15:07:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
                 "shasum": ""
             },
             "require": {
@@ -62593,9 +61908,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -62634,7 +61946,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -62650,20 +61962,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "e46b4da57951a16053cd751f63f4a24292788157"
+                "reference": "e76343c631b453088e2260ac41dfebe21954de81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e46b4da57951a16053cd751f63f4a24292788157",
-                "reference": "e46b4da57951a16053cd751f63f4a24292788157",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e76343c631b453088e2260ac41dfebe21954de81",
+                "reference": "e76343c631b453088e2260ac41dfebe21954de81",
                 "shasum": ""
             },
             "require": {
@@ -62674,9 +61986,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -62721,7 +62030,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -62737,20 +62046,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-21T17:27:24+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
+                "reference": "a6e83bdeb3c84391d1dfe16f42e40727ce524a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
-                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a6e83bdeb3c84391d1dfe16f42e40727ce524a5c",
+                "reference": "a6e83bdeb3c84391d1dfe16f42e40727ce524a5c",
                 "shasum": ""
             },
             "require": {
@@ -62763,9 +62072,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -62808,7 +62114,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -62824,20 +62130,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:30:37+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
-                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
                 "shasum": ""
             },
             "require": {
@@ -62848,9 +62154,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -62892,7 +62195,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -62908,20 +62211,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -62935,9 +62238,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -62975,7 +62275,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -62991,20 +62291,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.28.0",
+            "name": "symfony/polyfill-php72",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "10112722600777e02d2745716b70c5db4ca70442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
-                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/10112722600777e02d2745716b70c5db4ca70442",
+                "reference": "10112722600777e02d2745716b70c5db4ca70442",
                 "shasum": ""
             },
             "require": {
@@ -63012,9 +62312,79 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-06-19T12:30:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -63054,7 +62424,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -63070,20 +62440,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
                 "shasum": ""
             },
             "require": {
@@ -63091,9 +62461,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -63137,7 +62504,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -63153,31 +62520,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.28.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
+                "reference": "dbdcdf1a4dcc2743591f1079d0c35ab1e2dcbbc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
-                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/dbdcdf1a4dcc2743591f1079d0c35ab1e2dcbbc9",
+                "reference": "dbdcdf1a4dcc2743591f1079d0c35ab1e2dcbbc9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "symfony/polyfill-php80": "^1.14"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -63217,7 +62580,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -63233,102 +62596,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-16T06:22:46+00:00"
-        },
-        {
-            "name": "symfony/polyfill-uuid",
-            "version": "v1.28.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e",
-                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-uuid": "*"
-            },
-            "suggest": {
-                "ext-uuid": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Uuid\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for uuid functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.28.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-06-19T12:35:24+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.3.4",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0b5c29118f2e980d455d2e34a5659f4579847c54"
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0b5c29118f2e980d455d2e34a5659f4579847c54",
-                "reference": "0b5c29118f2e980d455d2e34a5659f4579847c54",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
                 "shasum": ""
             },
             "require": {
@@ -63360,7 +62641,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.3.4"
+                "source": "https://github.com/symfony/process/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -63376,29 +62657,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T10:39:22+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v6.3.2",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "2dc4f9da444b8f8ff592e95d570caad67924f1d0"
+                "reference": "e4d9b00983612f9c0013ca37c61affdba2dd975a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/2dc4f9da444b8f8ff592e95d570caad67924f1d0",
-                "reference": "2dc4f9da444b8f8ff592e95d570caad67924f1d0",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/e4d9b00983612f9c0013ca37c61affdba2dd975a",
+                "reference": "e4d9b00983612f9c0013ca37c61affdba2dd975a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/property-info": "^5.4|^6.0"
+                "symfony/property-info": "^5.4|^6.0|^7.0"
             },
             "require-dev": {
-                "symfony/cache": "^5.4|^6.0"
+                "symfony/cache": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63437,7 +62718,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v6.3.2"
+                "source": "https://github.com/symfony/property-access/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -63453,38 +62734,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-13T15:26:11+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v6.3.0",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "7f3a03716112269741fe2a809f8f791a371d1fcd"
+                "reference": "1a0357ed93a6ab09482435a7818defaa85cad69b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/7f3a03716112269741fe2a809f8f791a371d1fcd",
-                "reference": "7f3a03716112269741fe2a809f8f791a371d1fcd",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/1a0357ed93a6ab09482435a7818defaa85cad69b",
+                "reference": "1a0357ed93a6ab09482435a7818defaa85cad69b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<5.2",
                 "phpdocumentor/type-resolver": "<1.5.1",
-                "symfony/dependency-injection": "<5.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/serializer": "<6.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.10.4|^2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "phpstan/phpdoc-parser": "^1.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0"
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63520,7 +62801,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v6.3.0"
+                "source": "https://github.com/symfony/property-info/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -63536,20 +62817,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-19T08:06:44+00:00"
+            "time": "2024-06-21T16:04:15+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.3.5",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "82616e59acd3e3d9c916bba798326cb7796d7d31"
+                "reference": "8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/82616e59acd3e3d9c916bba798326cb7796d7d31",
-                "reference": "82616e59acd3e3d9c916bba798326cb7796d7d31",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58",
+                "reference": "8a40d0f9b01f0fbb80885d3ce0ad6714fb603a58",
                 "shasum": ""
             },
             "require": {
@@ -63565,11 +62846,11 @@
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.2",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/config": "^6.2|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63603,7 +62884,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.3.5"
+                "source": "https://github.com/symfony/routing/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -63619,135 +62900,49 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-20T16:05:51+00:00"
-        },
-        {
-            "name": "symfony/runtime",
-            "version": "v6.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/runtime.git",
-                "reference": "d5c09493647a0c1a16e6c8da308098e840d1164f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/runtime/zipball/d5c09493647a0c1a16e6c8da308098e840d1164f",
-                "reference": "d5c09493647a0c1a16e6c8da308098e840d1164f",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0|^2.0",
-                "php": ">=8.1"
-            },
-            "conflict": {
-                "symfony/dotenv": "<5.4"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0.2|^2.0",
-                "symfony/console": "^5.4.9|^6.0.9",
-                "symfony/dotenv": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Symfony\\Component\\Runtime\\Internal\\ComposerPlugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Runtime\\": "",
-                    "Symfony\\Runtime\\Symfony\\Component\\": "Internal/"
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Enables decoupling PHP applications from global state",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "runtime"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/runtime/tree/v6.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-07-16T17:05:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v5.4.30",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928"
+                "reference": "2d58f4c3ff50b1b4eef0a333c2b1e3eef46807f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/3908c54da30dd68c2fe31915d82a1c81809d1928",
-                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/2d58f4c3ff50b1b4eef0a333c2b1e3eef46807f4",
+                "reference": "2d58f4c3ff50b1b4eef0a333c2b1e3eef46807f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^1.1|^2|^3",
-                "symfony/password-hasher": "^5.3|^6.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1.6|^2|^3"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher-contracts": "^2.5|^3",
+                "symfony/password-hasher": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/http-foundation": "<5.3",
-                "symfony/ldap": "<4.4",
-                "symfony/security-guard": "<4.4",
-                "symfony/validator": "<5.2"
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/http-foundation": "<5.4",
+                "symfony/ldap": "<5.4",
+                "symfony/security-guard": "<5.4",
+                "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3|>=7.0,<7.0.3",
+                "symfony/validator": "<5.4"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "psr/container": "^1.0|^2.0",
+                "psr/container": "^1.1|^2.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^5.3|^6.0",
-                "symfony/ldap": "^4.4|^5.0|^6.0",
-                "symfony/translation": "^4.4|^5.0|^6.0",
-                "symfony/validator": "^5.2|^6.0"
-            },
-            "suggest": {
-                "psr/container-implementation": "To instantiate the Security class",
-                "symfony/event-dispatcher": "",
-                "symfony/expression-language": "For using the expression voter",
-                "symfony/http-foundation": "",
-                "symfony/ldap": "For using LDAP integration",
-                "symfony/validator": "For using the user password constraint"
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/ldap": "^5.4|^6.0|^7.0",
+                "symfony/string": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4.35|~6.3.12|^6.4.3|^7.0.3",
+                "symfony/validator": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63775,7 +62970,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v5.4.30"
+                "source": "https://github.com/symfony/security-core/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -63791,31 +62986,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-27T07:38:28+00:00"
+            "time": "2024-06-28T07:59:05+00:00"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v6.3.2",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "63d7b098c448cbddb46ea5eda33b68c1ece6eb5b"
+                "reference": "f46ab02b76311087873257071559edcaf6d7ab99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/63d7b098c448cbddb46ea5eda33b68c1ece6eb5b",
-                "reference": "63d7b098c448cbddb46ea5eda33b68c1ece6eb5b",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/f46ab02b76311087873257071559edcaf6d7ab99",
+                "reference": "f46ab02b76311087873257071559edcaf6d7ab99",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/security-core": "^5.4|^6.0"
+                "symfony/security-core": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/http-foundation": "<5.4"
             },
             "require-dev": {
-                "symfony/http-foundation": "^5.4|^6.0"
+                "symfony/http-foundation": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63843,7 +63038,7 @@
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-csrf/tree/v6.3.2"
+                "source": "https://github.com/symfony/security-csrf/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -63859,28 +63054,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-05T08:41:27+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/security-guard",
-            "version": "v5.4.27",
+            "version": "v5.4.0-BETA1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-guard.git",
-                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc"
+                "reference": "80c6fabecc78e40cf2c804f7d2a738d447458471"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-guard/zipball/72c53142533462fc6fda4a429c2a21c2b944a8cc",
-                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc",
+                "url": "https://api.github.com/repos/symfony/security-guard/zipball/80c6fabecc78e40cf2c804f7d2a738d447458471",
+                "reference": "80c6fabecc78e40cf2c804f7d2a738d447458471",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-php80": "^1.15",
-                "symfony/security-core": "^5.0",
-                "symfony/security-http": "^5.3"
+                "symfony/security-core": "^5.0|^6.0",
+                "symfony/security-http": "^5.3|^6.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3"
@@ -63911,7 +63105,7 @@
             "description": "Symfony Security Component - Guard",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-guard/tree/v5.4.27"
+                "source": "https://github.com/symfony/security-guard/tree/v5.4.0-BETA1"
             },
             "funding": [
                 {
@@ -63927,49 +63121,51 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T14:44:35+00:00"
+            "time": "2021-11-03T09:24:47+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v5.4.31",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9"
+                "reference": "8e70f39626ada36c5492c3aff9369c85d2840948"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/6d3cd5a4deee9697738db8d24258890ca4140ae9",
-                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/8e70f39626ada36c5492c3aff9369c85d2840948",
+                "reference": "8e70f39626ada36c5492c3aff9369c85d2840948",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/http-foundation": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-foundation": "^6.2|^7.0",
+                "symfony/http-kernel": "^6.3|^7.0",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/property-access": "^4.4|^5.0|^6.0",
-                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5",
-                "symfony/service-contracts": "^1.10|^2|^3"
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/event-dispatcher": "<4.3",
-                "symfony/security-bundle": "<5.3",
-                "symfony/security-csrf": "<4.4"
+                "symfony/clock": "<6.3",
+                "symfony/event-dispatcher": "<5.4.9|>=6,<6.0.9",
+                "symfony/http-client-contracts": "<3.0",
+                "symfony/security-bundle": "<5.4",
+                "symfony/security-csrf": "<5.4"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/cache": "^4.4|^5.0|^6.0",
-                "symfony/rate-limiter": "^5.2|^6.0",
-                "symfony/routing": "^4.4|^5.0|^6.0",
-                "symfony/security-csrf": "^4.4|^5.0|^6.0",
-                "symfony/translation": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs",
-                "symfony/security-csrf": "For using tokens to protect authentication/logout attempts"
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/clock": "^6.3|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-client-contracts": "^3.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/security-csrf": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0",
+                "web-token/jwt-checker": "^3.1",
+                "web-token/jwt-signature-algorithm-ecdsa": "^3.1"
             },
             "type": "library",
             "autoload": {
@@ -63997,7 +63193,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v5.4.31"
+                "source": "https://github.com/symfony/security-http/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -64013,20 +63209,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-03T16:13:08+00:00"
+            "time": "2024-06-21T16:04:15+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.3.7",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "641472dd3d6dc3c4d0fdd1496ebd1b55c72e43d9"
+                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/641472dd3d6dc3c4d0fdd1496ebd1b55c72e43d9",
-                "reference": "641472dd3d6dc3c4d0fdd1496ebd1b55c72e43d9",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/56ce31d19127e79647ac53387c7555bdcd5730ce",
+                "reference": "56ce31d19127e79647ac53387c7555bdcd5730ce",
                 "shasum": ""
             },
             "require": {
@@ -64042,28 +63238,32 @@
                 "symfony/property-access": "<5.4",
                 "symfony/property-info": "<5.4.24|>=6,<6.2.11",
                 "symfony/uid": "<5.4",
+                "symfony/validator": "<6.4",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/form": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4.24|^6.2.11",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0",
-                "symfony/var-exporter": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/form": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4.26|^6.3|^7.0",
+                "symfony/property-info": "^5.4.24|^6.2.11|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64091,7 +63291,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.3.7"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -64107,37 +63307,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-26T18:15:14+00:00"
+            "time": "2024-06-28T07:59:05+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.2",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1|^3"
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -64147,7 +63344,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -64174,7 +63374,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -64190,20 +63390,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:17:29+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.3.0",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2"
+                "reference": "63e069eb616049632cde9674c46957819454b8aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2",
-                "reference": "fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/63e069eb616049632cde9674c46957819454b8aa",
+                "reference": "63e069eb616049632cde9674c46957819454b8aa",
                 "shasum": ""
             },
             "require": {
@@ -64236,7 +63436,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.3.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -64252,20 +63452,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T10:14:28+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.3.5",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339"
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/13d76d0fb049051ed12a04bef4f9de8715bea339",
-                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339",
+                "url": "https://api.github.com/repos/symfony/string/zipball/76792dbd99690a5ebef8050d9206c60c59e681d7",
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7",
                 "shasum": ""
             },
             "require": {
@@ -64279,11 +63479,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/intl": "^6.2",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^6.2|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64322,7 +63522,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.5"
+                "source": "https://github.com/symfony/string/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -64338,20 +63538,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-18T10:38:32+00:00"
+            "time": "2024-06-28T09:25:38+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.3.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "30212e7c87dcb79c83f6362b00bde0e0b1213499"
+                "reference": "a002933b13989fc4bd0b58e04bf7eec5210e438a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/30212e7c87dcb79c83f6362b00bde0e0b1213499",
-                "reference": "30212e7c87dcb79c83f6362b00bde0e0b1213499",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a002933b13989fc4bd0b58e04bf7eec5210e438a",
+                "reference": "a002933b13989fc4bd0b58e04bf7eec5210e438a",
                 "shasum": ""
             },
             "require": {
@@ -64374,19 +63574,19 @@
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.18|^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64417,7 +63617,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.3.7"
+                "source": "https://github.com/symfony/translation/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -64433,20 +63633,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:11:45+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86"
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/02c24deb352fb0d79db5486c0c79905a85e37e86",
-                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
                 "shasum": ""
             },
             "require": {
@@ -64455,7 +63655,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -64495,7 +63695,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -64511,20 +63711,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-30T17:17:10+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v6.3.8",
+            "version": "v6.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "c51407623959a626784ff302419026f56dc4e1ba"
+                "reference": "dd34e348a9237d40eb7a791ee14de6efbadd5108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/c51407623959a626784ff302419026f56dc4e1ba",
-                "reference": "c51407623959a626784ff302419026f56dc4e1ba",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/dd34e348a9237d40eb7a791ee14de6efbadd5108",
+                "reference": "dd34e348a9237d40eb7a791ee14de6efbadd5108",
                 "shasum": ""
             },
             "require": {
@@ -64567,7 +63767,7 @@
                 "symfony/security-core": "^5.4|^6.0",
                 "symfony/security-csrf": "^5.4|^6.0",
                 "symfony/security-http": "^5.4|^6.0",
-                "symfony/serializer": "^6.2",
+                "symfony/serializer": "~6.3.12|^6.4.3",
                 "symfony/stopwatch": "^5.4|^6.0",
                 "symfony/translation": "^6.1",
                 "symfony/web-link": "^5.4|^6.0",
@@ -64603,7 +63803,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v6.3.8"
+                "source": "https://github.com/symfony/twig-bridge/tree/v6.3.12"
             },
             "funding": [
                 {
@@ -64619,94 +63819,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-09T21:20:12+00:00"
-        },
-        {
-            "name": "symfony/uid",
-            "version": "v6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/uid.git",
-                "reference": "01b0f20b1351d997711c56f1638f7a8c3061e384"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/01b0f20b1351d997711c56f1638f7a8c3061e384",
-                "reference": "01b0f20b1351d997711c56f1638f7a8c3061e384",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-uuid": "^1.15"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Uid\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Grégoire Pineau",
-                    "email": "lyrixx@lyrixx.info"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to generate and represent UIDs",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "UID",
-                "ulid",
-                "uuid"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/uid/tree/v6.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-04-08T07:25:02+00:00"
+            "time": "2024-01-30T08:17:33+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v6.3.7",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "9cc736663fa5839b9710ac2c303bb0b951014fc1"
+                "reference": "ee0a4d6a327a963aee094f730da238f7ea18cb01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/9cc736663fa5839b9710ac2c303bb0b951014fc1",
-                "reference": "9cc736663fa5839b9710ac2c303bb0b951014fc1",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/ee0a4d6a327a963aee094f730da238f7ea18cb01",
+                "reference": "ee0a4d6a327a963aee094f730da238f7ea18cb01",
                 "shasum": ""
             },
             "require": {
@@ -64725,27 +63851,27 @@
                 "symfony/http-kernel": "<5.4",
                 "symfony/intl": "<5.4",
                 "symfony/property-info": "<5.4",
-                "symfony/translation": "<5.4",
+                "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3|>=7.0,<7.0.3",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13|^2",
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4.35|~6.3.12|^6.4.3|^7.0.3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64753,7 +63879,8 @@
                     "Symfony\\Component\\Validator\\": ""
                 },
                 "exclude-from-classmap": [
-                    "/Tests/"
+                    "/Tests/",
+                    "/Resources/bin/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -64773,7 +63900,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.3.7"
+                "source": "https://github.com/symfony/validator/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -64789,20 +63916,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:11:45+00:00"
+            "time": "2024-06-22T07:42:41+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.3.6",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "999ede244507c32b8e43aebaa10e9fce20de7c97"
+                "reference": "c31566e4ca944271cc8d8ac6887cbf31b8c6a172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/999ede244507c32b8e43aebaa10e9fce20de7c97",
-                "reference": "999ede244507c32b8e43aebaa10e9fce20de7c97",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c31566e4ca944271cc8d8ac6887cbf31b8c6a172",
+                "reference": "c31566e4ca944271cc8d8ac6887cbf31b8c6a172",
                 "shasum": ""
             },
             "require": {
@@ -64815,10 +63942,11 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.3|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/uid": "^5.4|^6.0|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "bin": [
@@ -64857,7 +63985,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.3.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -64873,94 +64001,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-12T18:45:56+00:00"
-        },
-        {
-            "name": "symfony/var-exporter",
-            "version": "v6.3.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "374d289c13cb989027274c86206ddc63b16a2441"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/374d289c13cb989027274c86206ddc63b16a2441",
-                "reference": "374d289c13cb989027274c86206ddc63b16a2441",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\VarExporter\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "clone",
-                "construct",
-                "export",
-                "hydrate",
-                "instantiate",
-                "lazy-loading",
-                "proxy",
-                "serialize"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.3.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-13T09:16:49+00:00"
+            "time": "2024-06-27T13:23:14+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.3.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9758b6c69d179936435d0ffb577c3708d57e38a8"
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9758b6c69d179936435d0ffb577c3708d57e38a8",
-                "reference": "9758b6c69d179936435d0ffb577c3708d57e38a8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/52903de178d542850f6f341ba92995d3d63e60c9",
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9",
                 "shasum": ""
             },
             "require": {
@@ -64972,7 +64026,7 @@
                 "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -65003,7 +64057,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.3.7"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -65019,30 +64073,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-28T23:31:00+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.7.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a0ce373a0ca3bf6c64b9e3e2124aca502ba39554"
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a0ce373a0ca3bf6c64b9e3e2124aca502ba39554",
-                "reference": "a0ce373a0ca3bf6c64b9e3e2124aca502ba39554",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^5.4.9|^6.3"
+                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -65078,7 +64133,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.7.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -65090,7 +64145,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-28T11:09:02+00:00"
+            "time": "2023-11-21T18:54:41+00:00"
         },
         {
             "name": "voku/anti-xss",
@@ -65728,16 +64783,16 @@
         },
         {
             "name": "webmozart/glob",
-            "version": "4.6.0",
+            "version": "4.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/glob.git",
-                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655"
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/glob/zipball/3c17f7dec3d9d0e87b575026011f2e75a56ed655",
-                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/8a2842112d6916e61e0e15e316465b611f3abc17",
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17",
                 "shasum": ""
             },
             "require": {
@@ -65771,9 +64826,9 @@
             "description": "A PHP implementation of Ant's glob.",
             "support": {
                 "issues": "https://github.com/webmozarts/glob/issues",
-                "source": "https://github.com/webmozarts/glob/tree/4.6.0"
+                "source": "https://github.com/webmozarts/glob/tree/4.7.0"
             },
-            "time": "2022-05-24T19:45:58+00:00"
+            "time": "2024-03-07T20:33:40+00:00"
         },
         {
             "name": "willdurand/negotiation",
@@ -68373,28 +67428,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
+            "version": "5.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
+                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
+                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.1",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
+                "mockery/mockery": "~1.3.5",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "vimeo/psalm": "^5.13"
             },
             "type": "library",
             "extra": {
@@ -68418,33 +67480,33 @@
                 },
                 {
                     "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
+                    "email": "opensource@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.4.1"
             },
-            "time": "2021-10-19T17:43:47+00:00"
+            "time": "2024-05-21T05:55:05+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.7.3",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419"
+                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
-                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
+                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
                 "phpstan/phpdoc-parser": "^1.13"
             },
@@ -68482,9 +67544,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.3"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
             },
-            "time": "2023-08-12T11:01:26+00:00"
+            "time": "2024-02-23T11:10:43+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -68572,16 +67634,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.2",
+            "version": "1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "bcad8d995980440892759db0c32acae7c8e79442"
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bcad8d995980440892759db0c32acae7c8e79442",
-                "reference": "bcad8d995980440892759db0c32acae7c8e79442",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
                 "shasum": ""
             },
             "require": {
@@ -68613,9 +67675,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
-            "time": "2023-09-26T12:28:12+00:00"
+            "time": "2024-05-31T08:52:43+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -71282,6 +70344,178 @@
             "time": "2023-07-06T06:56:43+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v6.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "84aff8d948d6292d2b5a01ac622760be44dddc72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/84aff8d948d6292d2b5a01ac622760be44dddc72",
+                "reference": "84aff8d948d6292d2b5a01ac622760be44dddc72",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.3.6"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13.1",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/var-dumper": "<5.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/messenger": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v6.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-17T14:44:58+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "df6a1a44c890faded49a5fca33c2d5c5fd3c2197"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/df6a1a44c890faded49a5fca33c2d5c5fd3c2197",
+                "reference": "df6a1a44c890faded49a5fca33c2d5c5fd3c2197",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        },
+        {
             "name": "symfony/css-selector",
             "version": "v6.3.2",
             "source": {
@@ -71345,6 +70579,87 @@
                 }
             ],
             "time": "2023-07-12T16:00:22+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v6.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2ed62b3bf98346e1f45529a7b6be2196739bb993",
+                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.2.10"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.1",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<6.3",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.1",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-09-25T16:46:40+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -71412,6 +70727,150 @@
                 }
             ],
             "time": "2023-08-01T07:43:40+00:00"
+        },
+        {
+            "name": "symfony/framework-bundle",
+            "version": "v6.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/framework-bundle.git",
+                "reference": "dba20792c726c30d455626eddfb2db008f64085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/dba20792c726c30d455626eddfb2db008f64085f",
+                "reference": "dba20792c726c30d455626eddfb2db008f64085f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.1",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.3.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.1",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.3",
+                "symfony/http-kernel": "^6.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/routing": "^5.4|^6.0"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.13.1",
+                "doctrine/persistence": "<1.3",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/asset": "<5.4",
+                "symfony/clock": "<6.3",
+                "symfony/console": "<5.4",
+                "symfony/dom-crawler": "<6.3",
+                "symfony/dotenv": "<5.4",
+                "symfony/form": "<5.4",
+                "symfony/http-client": "<6.3",
+                "symfony/lock": "<5.4",
+                "symfony/mailer": "<5.4",
+                "symfony/messenger": "<6.3",
+                "symfony/mime": "<6.2",
+                "symfony/property-access": "<5.4",
+                "symfony/property-info": "<5.4",
+                "symfony/security-core": "<5.4",
+                "symfony/security-csrf": "<5.4",
+                "symfony/serializer": "<6.3",
+                "symfony/stopwatch": "<5.4",
+                "symfony/translation": "<6.2.8",
+                "symfony/twig-bridge": "<5.4",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/validator": "<6.3",
+                "symfony/web-profiler-bundle": "<5.4",
+                "symfony/workflow": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13.1|^2",
+                "doctrine/persistence": "^1.3|^2|^3",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/asset": "^5.4|^6.0",
+                "symfony/asset-mapper": "^6.3",
+                "symfony/browser-kit": "^5.4|^6.0",
+                "symfony/clock": "^6.2",
+                "symfony/console": "^5.4.9|^6.0.9",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dom-crawler": "^6.3",
+                "symfony/dotenv": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/html-sanitizer": "^6.1",
+                "symfony/http-client": "^6.3",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/mailer": "^5.4|^6.0",
+                "symfony/messenger": "^6.3",
+                "symfony/mime": "^6.2",
+                "symfony/notifier": "^5.4|^6.0",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/rate-limiter": "^5.4|^6.0",
+                "symfony/scheduler": "^6.3",
+                "symfony/security-bundle": "^5.4|^6.0",
+                "symfony/semaphore": "^5.4|^6.0",
+                "symfony/serializer": "^6.3",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/string": "^5.4|^6.0",
+                "symfony/translation": "^6.2.8",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "symfony/validator": "^6.3",
+                "symfony/web-link": "^5.4|^6.0",
+                "symfony/workflow": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0",
+                "twig/twig": "^2.10|^3.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\FrameworkBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-26T18:15:14+00:00"
         },
         {
             "name": "symfony/twig-bundle",
@@ -71497,6 +70956,80 @@
                 }
             ],
             "time": "2023-05-06T09:53:41+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v6.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "374d289c13cb989027274c86206ddc63b16a2441"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/374d289c13cb989027274c86206ddc63b16a2441",
+                "reference": "374d289c13cb989027274c86206ddc63b16a2441",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-13T09:16:49+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -55110,16 +55110,16 @@
         },
         {
             "name": "spryker/state-machine",
-            "version": "2.19.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/state-machine.git",
-                "reference": "f9305392e0336cfbbf6ba581a7a1ff649662e663"
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/state-machine/zipball/f9305392e0336cfbbf6ba581a7a1ff649662e663",
-                "reference": "f9305392e0336cfbbf6ba581a7a1ff649662e663",
+                "url": "https://api.github.com/repos/spryker/state-machine/zipball/c14a7b53e43d223cbedd85ed2eed976041f93e28",
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28",
                 "shasum": ""
             },
             "require": {
@@ -55131,6 +55131,7 @@
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-network": "^1.1.0",
+                "spryker/util-sanitize-xss": "^1.1.0",
                 "spryker/util-text": "^1.1.0"
             },
             "require-dev": {
@@ -55157,9 +55158,9 @@
             ],
             "description": "StateMachine module",
             "support": {
-                "source": "https://github.com/spryker/state-machine/tree/2.19.0"
+                "source": "https://github.com/spryker/state-machine/tree/2.20.0"
             },
-            "time": "2023-11-02T20:09:27+00:00"
+            "time": "2023-11-29T09:16:52+00:00"
         },
         {
             "name": "spryker/step-engine",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -768,6 +768,14 @@ $config[MessageBrokerAwsConstants::MESSAGE_TO_CHANNEL_MAP] = [
     ConfigureTaxAppTransfer::class => 'tax-commands',
     DeleteTaxAppTransfer::class => 'tax-commands',
     SubmitPaymentTaxInvoiceTransfer::class => 'payment-tax-invoice-commands',
+    \Generated\Shared\Transfer\AddPaymentMethodTransfer::class => 'payment-method-commands',
+    \Generated\Shared\Transfer\DeletePaymentMethodTransfer::class => 'payment-method-commands',
+    \Generated\Shared\Transfer\PaymentAuthorizedTransfer::class => 'payment-events',
+    \Generated\Shared\Transfer\PaymentAuthorizationFailedTransfer::class => 'payment-events',
+    \Generated\Shared\Transfer\PaymentCapturedTransfer::class => 'payment-events',
+    \Generated\Shared\Transfer\PaymentCaptureFailedTransfer::class => 'payment-events',
+    \Generated\Shared\Transfer\PaymentCanceledTransfer::class => 'payment-events',
+    \Generated\Shared\Transfer\PaymentCancellationFailedTransfer::class => 'payment-events',
 ];
 
 $config[MessageBrokerConstants::CHANNEL_TO_RECEIVER_TRANSPORT_MAP] = [
@@ -857,3 +865,29 @@ $config[GlueStorefrontApiApplicationConstants::GLUE_STOREFRONT_CORS_ALLOW_ORIGIN
 $config[PushNotificationWebPushPhpConstants::VAPID_PUBLIC_KEY] = getenv('SPRYKER_PUSH_NOTIFICATION_WEB_PUSH_PHP_VAPID_PUBLIC_KEY');
 $config[PushNotificationWebPushPhpConstants::VAPID_PRIVATE_KEY] = getenv('SPRYKER_PUSH_NOTIFICATION_WEB_PUSH_PHP_VAPID_PRIVATE_KEY');
 $config[PushNotificationWebPushPhpConstants::VAPID_SUBJECT] = getenv('SPRYKER_PUSH_NOTIFICATION_WEB_PUSH_PHP_VAPID_SUBJECT');
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOG_SANITIZE_FIELDS] = [
+    'password',
+];
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOGGER_CONFIG_PLUGINS_YVES] = [
+    \Spryker\Yves\Log\Plugin\Log\YvesSecurityAuditLoggerConfigPlugin::class,
+];
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOGGER_CONFIG_PLUGINS_ZED] = [
+    \Spryker\Zed\Log\Communication\Plugin\Log\ZedSecurityAuditLoggerConfigPlugin::class,
+];
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOGGER_CONFIG_PLUGINS_GLUE] = [
+    \Spryker\Glue\Log\Plugin\Log\GlueSecurityAuditLoggerConfigPlugin::class,
+];
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOGGER_CONFIG_PLUGINS_GLUE_BACKEND] = [
+    \Spryker\Glue\Log\Plugin\Log\GlueBackendSecurityAuditLoggerConfigPlugin::class,
+];
+
+$config[\Spryker\Shared\Log\LogConstants::AUDIT_LOGGER_CONFIG_PLUGINS_MERCHANT_PORTAL] = [
+    \Spryker\Zed\Log\Communication\Plugin\Log\MerchantPortalSecurityAuditLoggerConfigPlugin::class,
+];
+
+$config[\Spryker\Shared\Product\ProductConstants::PUBLISHING_TO_MESSAGE_BROKER_ENABLED] = $config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::IS_ENABLED];

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -3300,3 +3300,5 @@ product_offer_shipment_type.validation.product_offer_not_unique,A product offer 
 product_offer_shipment_type.validation.product_offer_not_unique,Ein Product Offer mit der gleichen Referenz liegt bereits in der Anfrage vor.,de_DE
 product_offer_shipment_type.validation.shipment_type_not_unique,A delivery type for product offer '%product_offer_reference%' with the same uuid already exists in request.,de_DE
 product_offer_shipment_type.validation.shipment_type_not_unique,Ein Lieferart für Product Offer '%product_offer_reference%' mit derselben UUID ist bereits in der Anfrage vorhanden.,de_DE
+category.validation.category_node_entity_not_found,The category node ID '%category_node_id%' cannot be relocated because this category node no longer exists.,en_US
+category.validation.category_node_entity_not_found,"Die Kategorieknoten-ID '%category_node_id%' kann nicht verschoben werden, da dieser Kategorieknoten nicht mehr existiert.",de_DE

--- a/src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php
+++ b/src/Pyz/Glue/GlueBackendApiApplication/GlueBackendApiApplicationDependencyProvider.php
@@ -54,6 +54,7 @@ class GlueBackendApiApplicationDependencyProvider extends SprykerGlueBackendApiA
             new RouterApplicationPlugin(),
             new EventDispatcherApplicationPlugin(),
             new StoreHttpHeaderApplicationPlugin(),
+            new Spryker\Glue\Locale\Plugin\Application\LocaleApplicationPlugin(),
         ];
     }
 

--- a/src/Pyz/Glue/Log/LogDependencyProvider.php
+++ b/src/Pyz/Glue/Log/LogDependencyProvider.php
@@ -44,4 +44,50 @@ class LogDependencyProvider extends SprykerLogDependencyProvider
             new GuzzleBodyProcessorPlugin(),
         ];
     }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogHandlerPluginInterface>
+     */
+    protected function getGlueSecurityAuditLogHandlerPlugins() : array
+    {
+        return [
+            new Spryker\Glue\Log\Plugin\Log\AuditLogTagFilterBufferedStreamHandlerPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogHandlerPluginInterface>
+     */
+    protected function getGlueBackendSecurityAuditLogHandlerPlugins() : array
+    {
+        return [
+            new Spryker\Glue\Log\Plugin\Log\AuditLogTagFilterBufferedStreamHandlerPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogProcessorPluginInterface>
+     */
+    protected function getGlueSecurityAuditLogProcessorPlugins() : array
+    {
+        return [
+            new Spryker\Glue\Log\Plugin\Processor\PsrLogMessageProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\EnvironmentProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\ServerProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Log\AuditLogRequestProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\ResponseProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Log\AuditLogMetaDataProcessorPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogProcessorPluginInterface>
+     */
+    protected function getGlueBackendSecurityAuditLogProcessorPlugins() : array
+    {
+        return [
+            new Spryker\Glue\Log\Plugin\Processor\PsrLogMessageProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\EnvironmentProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\ServerProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Log\AuditLogRequestProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Processor\ResponseProcessorPlugin(),
+            new Spryker\Glue\Log\Plugin\Log\AuditLogMetaDataProcessorPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
+++ b/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
@@ -12,6 +12,11 @@ use SprykerShop\Yves\CustomerPage\CustomerPageConfig as SprykerCustomerPageConfi
 class CustomerPageConfig extends SprykerCustomerPageConfig
 {
     /**
+     * @var bool
+     */
+    protected const CUSTOMER_SECURITY_BLOCKER_ENABLED = true;
+
+    /**
      * @var string
      */
     protected const LOGIN_FAILURE_REDIRECT_URL = '/login';

--- a/src/Pyz/Yves/CustomerPage/CustomerPageDependencyProvider.php
+++ b/src/Pyz/Yves/CustomerPage/CustomerPageDependencyProvider.php
@@ -59,7 +59,7 @@ class CustomerPageDependencyProvider extends SprykerShopCustomerPageDependencyPr
     protected function getAfterCustomerAuthenticationSuccessPlugins(): array
     {
         return [
-            new FixAgentTokenAfterCustomerAuthenticationSuccessPlugin(),
+            new SprykerShop\Yves\AgentPage\Plugin\Security\UpdateAgentTokenAfterCustomerAuthenticationSuccessPlugin(),
             new UpdateAgentSessionAfterCustomerAuthenticationSuccessPlugin(),
         ];
     }

--- a/src/Pyz/Yves/Log/LogDependencyProvider.php
+++ b/src/Pyz/Yves/Log/LogDependencyProvider.php
@@ -44,4 +44,27 @@ class LogDependencyProvider extends SprykerLogDependencyProvider
             new GuzzleBodyProcessorPlugin(),
         ];
     }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogHandlerPluginInterface>
+     */
+    protected function getYvesSecurityAuditLogHandlerPlugins() : array
+    {
+        return [
+            new Spryker\Yves\Log\Plugin\Log\AuditLogTagFilterBufferedStreamHandlerPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogProcessorPluginInterface>
+     */
+    protected function getYvesSecurityAuditLogProcessorPlugins() : array
+    {
+        return [
+            new Spryker\Yves\Log\Plugin\Processor\PsrLogMessageProcessorPlugin(),
+            new Spryker\Yves\Log\Plugin\Processor\EnvironmentProcessorPlugin(),
+            new Spryker\Yves\Log\Plugin\Processor\ServerProcessorPlugin(),
+            new Spryker\Yves\Log\Plugin\Log\AuditLogRequestProcessorPlugin(),
+            new Spryker\Yves\Log\Plugin\Processor\ResponseProcessorPlugin(),
+            new Spryker\Yves\Log\Plugin\Log\AuditLogMetaDataProcessorPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Yves/Security/SecurityDependencyProvider.php
+++ b/src/Pyz/Yves/Security/SecurityDependencyProvider.php
@@ -25,9 +25,10 @@ class SecurityDependencyProvider extends SprykerSecurityDependencyProvider
     protected function getSecurityPlugins(): array
     {
         return [
+            new SprykerShop\Yves\CustomerPage\Plugin\Security\CustomerRememberMeSecurityPlugin(),
+            new SprykerShop\Yves\AgentPage\Plugin\Security\YvesAgentPageSecurityPlugin(),
+            new SprykerShop\Yves\CustomerPage\Plugin\Security\YvesCustomerPageSecurityPlugin(),
             new RememberMeSecurityPlugin(),
-            new AgentPageSecurityPlugin(),
-            new CustomerPageSecurityPlugin(),
             new ValidateCustomerSessionSecurityPlugin(),
             new SaveCustomerSessionSecurityPlugin(),
             new ValidateAgentSessionSecurityPlugin(),

--- a/src/Pyz/Yves/ShopApplication/ShopApplicationDependencyProvider.php
+++ b/src/Pyz/Yves/ShopApplication/ShopApplicationDependencyProvider.php
@@ -270,7 +270,8 @@ class ShopApplicationDependencyProvider extends SprykerShopApplicationDependency
     protected function getApplicationPlugins(): array
     {
         $applicationPlugins = [
-            new HttpApplicationPlugin(),
+            new Spryker\Yves\Security\Plugin\Application\YvesSecurityApplicationPlugin(),
+            new Spryker\Yves\Http\Plugin\Application\YvesHttpApplicationPlugin(),
             new TwigApplicationPlugin(),
             new EventDispatcherApplicationPlugin(),
             new ShopApplicationApplicationPlugin(),
@@ -283,7 +284,6 @@ class ShopApplicationDependencyProvider extends SprykerShopApplicationDependency
             new FlashMessengerApplicationPlugin(),
             new FormApplicationPlugin(),
             new ValidatorApplicationPlugin(),
-            new SecurityApplicationPlugin(),
             new CustomerConfirmationUserCheckerApplicationPlugin(),
         ];
 

--- a/src/Pyz/Yves/Validator/ValidatorDependencyProvider.php
+++ b/src/Pyz/Yves/Validator/ValidatorDependencyProvider.php
@@ -33,7 +33,7 @@ class ValidatorDependencyProvider extends SprykerValidatorDependencyProvider
     protected function getConstraintPlugins(): array
     {
         return [
-            new UserPasswordValidatorConstraintPlugin(),
+            new Spryker\Yves\Security\Plugin\Validator\YvesUserPasswordValidatorConstraintPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Application/ApplicationDependencyProvider.php
+++ b/src/Pyz/Zed/Application/ApplicationDependencyProvider.php
@@ -56,7 +56,7 @@ class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
             new ErrorHandlerApplicationPlugin(),
             new FormApplicationPlugin(),
             new ValidatorApplicationPlugin(),
-            new SecurityApplicationPlugin(),
+            new Spryker\Zed\Security\Communication\Plugin\Application\ZedSecurityApplicationPlugin(),
             new NumberFormatterApplicationPlugin(),
             new BackofficeStoreApplicationPlugin(),
         ];
@@ -86,7 +86,7 @@ class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
             new ErrorHandlerApplicationPlugin(),
             new FormApplicationPlugin(),
             new ValidatorApplicationPlugin(),
-            new SecurityApplicationPlugin(),
+            new Spryker\Zed\Security\Communication\Plugin\Application\ZedSecurityApplicationPlugin(),
             new NumberFormatterApplicationPlugin(),
             new BackofficeStoreApplicationPlugin(),
         ];
@@ -104,7 +104,7 @@ class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
     protected function getBackendGatewayApplicationPlugins(): array
     {
         return [
-            new SecurityApplicationPlugin(),
+            new Spryker\Zed\Security\Communication\Plugin\Application\ZedSecurityApplicationPlugin(),
             new BackendGatewayEventDispatcherApplicationPlugin(),
             new RequestBackendGatewayApplicationPlugin(),
             new StoreBackendGatewayApplicationPlugin(),

--- a/src/Pyz/Zed/CheckoutRestApi/CheckoutRestApiDependencyProvider.php
+++ b/src/Pyz/Zed/CheckoutRestApi/CheckoutRestApiDependencyProvider.php
@@ -54,12 +54,12 @@ class CheckoutRestApiDependencyProvider extends SprykerCheckoutRestApiDependency
     protected function getCheckoutDataValidatorPlugins(): array
     {
         return [
-            new CountryCheckoutDataValidatorPlugin(),
             new ShipmentMethodCheckoutDataValidatorPlugin(),
             new ItemsCheckoutDataValidatorPlugin(),
             new CustomerAddressCheckoutDataValidatorPlugin(),
             new ShipmentTypeCheckoutDataValidatorPlugin(),
             new ClickAndCollectExampleReplaceCheckoutDataValidatorPlugin(),
+            new Spryker\Zed\Country\Communication\Plugin\CheckoutRestApi\CountriesCheckoutDataValidatorPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -395,6 +395,7 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
             new DateTimeProductConfiguratorBuildFrontendConsole(),
             new DeleteExpiredPushNotificationSubscriptionConsole(),
             new SendPushNotificationConsole(),
+            new Spryker\Zed\Oms\Communication\Console\ProcessCacheWarmUpConsole(),
         ];
 
         $propelCommands = $container->getLocator()->propel()->facade()->getConsoleCommands();

--- a/src/Pyz/Zed/Customer/CustomerConfig.php
+++ b/src/Pyz/Zed/Customer/CustomerConfig.php
@@ -12,6 +12,11 @@ use Spryker\Zed\Customer\CustomerConfig as SprykerCustomerConfig;
 class CustomerConfig extends SprykerCustomerConfig
 {
     /**
+     * @var bool
+     */
+    protected const PASSWORD_RESET_EXPIRATION_IS_ENABLED = true;
+
+    /**
      * @var int
      */
     protected const MIN_LENGTH_CUSTOMER_PASSWORD = 8;

--- a/src/Pyz/Zed/Log/LogDependencyProvider.php
+++ b/src/Pyz/Zed/Log/LogDependencyProvider.php
@@ -46,4 +46,50 @@ class LogDependencyProvider extends SprykerLogDependencyProvider
             new GuzzleBodyProcessorPlugin(),
         ];
     }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogHandlerPluginInterface>
+     */
+    protected function getZedSecurityAuditLogHandlerPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogTagFilterBufferedStreamHandlerPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogHandlerPluginInterface>
+     */
+    protected function getMerchantPortalSecurityAuditLogHandlerPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogTagFilterBufferedStreamHandlerPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogProcessorPluginInterface>
+     */
+    protected function getZedSecurityAuditLogProcessorPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Log\Communication\Plugin\Processor\PsrLogMessageProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\EnvironmentProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\ServerProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogRequestProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\ResponseProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogMetaDataProcessorPlugin(),
+        ];
+    }
+    /**
+     * @return list<\Spryker\Shared\Log\Dependency\Plugin\LogProcessorPluginInterface>
+     */
+    protected function getMerchantPortalSecurityAuditLogProcessorPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Log\Communication\Plugin\Processor\PsrLogMessageProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\EnvironmentProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\ServerProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogRequestProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Processor\ResponseProcessorPlugin(),
+            new Spryker\Zed\Log\Communication\Plugin\Log\AuditLogMetaDataProcessorPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Zed/MerchantPortalApplication/MerchantPortalApplicationDependencyProvider.php
+++ b/src/Pyz/Zed/MerchantPortalApplication/MerchantPortalApplicationDependencyProvider.php
@@ -47,7 +47,7 @@ class MerchantPortalApplicationDependencyProvider extends SprykerMerchantPortalA
             new FormApplicationPlugin(),
             new ValidatorApplicationPlugin(),
             new GuiTableApplicationPlugin(),
-            new SecurityApplicationPlugin(),
+            new Spryker\Zed\Security\Communication\Plugin\Application\ZedSecurityApplicationPlugin(),
             new ZedUiApplicationPlugin(),
             new AclEntityApplicationPlugin(),
             new MerchantPortalEventDispatcherApplicationPlugin(),

--- a/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
+++ b/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
@@ -61,14 +61,6 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
     public function getMessageHandlerPlugins(): array
     {
         return [
-            new PaymentCancelReservationFailedMessageHandlerPlugin(),
-            new PaymentConfirmationFailedMessageHandlerPlugin(),
-            new PaymentConfirmedMessageHandlerPlugin(),
-            new PaymentPreauthorizationFailedMessageHandlerPlugin(),
-            new PaymentPreauthorizedMessageHandlerPlugin(),
-            new PaymentReservationCanceledMessageHandlerPlugin(),
-            new PaymentRefundedMessageHandlerPlugin(),
-            new PaymentRefundFailedMessageHandlerPlugin(),
             new PaymentMethodMessageHandlerPlugin(),
             new AssetMessageHandlerPlugin(),
             new ProductExportMessageHandlerPlugin(),
@@ -76,6 +68,7 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
             new ProductReviewAddReviewsMessageHandlerPlugin(),
             new MerchantMessageHandlerPlugin(),
             new TaxAppMessageHandlerPlugin(),
+            new Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentOperationsMessageHandlerPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Oms/OmsDependencyProvider.php
+++ b/src/Pyz/Zed/Oms/OmsDependencyProvider.php
@@ -115,6 +115,7 @@ class OmsDependencyProvider extends SprykerOmsDependencyProvider
             $commandCollection->add(new GeneratePickingListsCommandByOrderPlugin(), 'PickingList/GeneratePickingLists');
             $commandCollection->add(new SalesOrderWarehouseAllocationCommandPlugin(), 'WarehouseAllocation/WarehouseAllocate');
             $commandCollection->add(new SubmitPaymentTaxInvoicePlugin(), 'TaxApp/SubmitPaymentTaxInvoice');
+            $commandCollection->add(new Spryker\Zed\Refund\Communication\Plugin\Oms\RefundCommandPlugin(), 'Payment/Refund/Confirm');
 
             return $commandCollection;
         });

--- a/src/Pyz/Zed/Product/ProductConfig.php
+++ b/src/Pyz/Zed/Product/ProductConfig.php
@@ -30,6 +30,16 @@ class ProductConfig extends SprykerProductConfig
             ProductImageEvents::PRODUCT_IMAGE_PRODUCT_ABSTRACT_PUBLISH,
             PriceProductEvents::PRICE_ABSTRACT_PUBLISH,
             ProductReviewEvents::PRODUCT_ABSTRACT_REVIEW_PUBLISH,
+            \Spryker\Zed\ProductCategory\Dependency\ProductCategoryEvents::ENTITY_SPY_PRODUCT_CATEGORY_CREATE,
+            \Spryker\Zed\ProductCategory\Dependency\ProductCategoryEvents::ENTITY_SPY_PRODUCT_CATEGORY_DELETE,
+            \Spryker\Zed\ProductLabel\Dependency\ProductLabelEvents::ENTITY_SPY_PRODUCT_LABEL_PRODUCT_ABSTRACT_CREATE,
+            \Spryker\Zed\ProductLabel\Dependency\ProductLabelEvents::ENTITY_SPY_PRODUCT_LABEL_PRODUCT_ABSTRACT_DELETE,
+            \Spryker\Zed\PriceProduct\Dependency\PriceProductEvents::ENTITY_SPY_PRICE_PRODUCT_CREATE,
+            \Spryker\Zed\PriceProduct\Dependency\PriceProductEvents::ENTITY_SPY_PRICE_PRODUCT_UPDATE,
+            \Spryker\Zed\ProductReview\Dependency\ProductReviewEvents::ENTITY_SPY_PRODUCT_REVIEW_CREATE,
+            \Spryker\Zed\ProductReview\Dependency\ProductReviewEvents::ENTITY_SPY_PRODUCT_REVIEW_UPDATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_CREATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_UPDATE,
         ];
     }
 
@@ -46,6 +56,17 @@ class ProductConfig extends SprykerProductConfig
             ProductEvents::PRODUCT_CONCRETE_PUBLISH,
             ProductBundleStorageConfig::PRODUCT_BUNDLE_PUBLISH,
             ProductImageEvents::PRODUCT_IMAGE_PRODUCT_CONCRETE_PUBLISH,
+            \Spryker\Shared\ProductBundleStorage\ProductBundleStorageConfig::ENTITY_SPY_PRODUCT_BUNDLE_CREATE,
+            \Spryker\Shared\ProductBundleStorage\ProductBundleStorageConfig::ENTITY_SPY_PRODUCT_BUNDLE_UPDATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_CREATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_UPDATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_TO_PRODUCT_IMAGE_CREATE,
+            \Spryker\Zed\ProductImage\Dependency\ProductImageEvents::ENTITY_SPY_PRODUCT_IMAGE_SET_TO_PRODUCT_IMAGE_UPDATE,
+            \Spryker\Zed\PriceProduct\Dependency\PriceProductEvents::PRICE_CONCRETE_PUBLISH,
+            \Spryker\Zed\PriceProduct\Dependency\PriceProductEvents::ENTITY_SPY_PRICE_PRODUCT_CREATE,
+            \Spryker\Zed\PriceProduct\Dependency\PriceProductEvents::ENTITY_SPY_PRICE_PRODUCT_UPDATE,
+            \Spryker\Zed\ProductSearch\Dependency\ProductSearchEvents::ENTITY_SPY_PRODUCT_SEARCH_CREATE,
+            \Spryker\Zed\ProductSearch\Dependency\ProductSearchEvents::ENTITY_SPY_PRODUCT_SEARCH_UPDATE,
         ];
     }
 }

--- a/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
+++ b/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
@@ -212,6 +212,7 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             $this->getStoreStoragePlugins(),
             $this->getAssetStoragePlugins(),
             $this->getCustomerStoragePlugins(),
+            $this->getProductMessageBrokerPlugins(),
             $this->getProductExportPlugins(),
             $this->getProductConfigurationStoragePlugins(),
             $this->getProductOfferAvailabilityStoragePlugins(),
@@ -581,20 +582,6 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
     /**
      * @return array<\Spryker\Zed\PublisherExtension\Dependency\Plugin\PublisherPluginInterface>
      */
-    protected function getProductExportPlugins(): array
-    {
-        return [
-            new ProductConcreteExportedMessageBrokerPublisherPlugin(),
-            new ProductConcreteCreatedMessageBrokerPublisherPlugin(),
-            new ProductConcreteUpdatedMessageBrokerPublisherPlugin(),
-            new ProductConcreteDeletedMessageBrokerPublisherPlugin(),
-            new ProductAbstractUpdatedMessageBrokerPublisherPlugin(),
-        ];
-    }
-
-    /**
-     * @return array<\Spryker\Zed\PublisherExtension\Dependency\Plugin\PublisherPluginInterface>
-     */
     protected function getProductOfferAvailabilityStoragePlugins(): array
     {
         return [
@@ -707,6 +694,20 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             new ProductOfferStoreProductOfferShipmentTypeWritePublisherPlugin(),
             new ShipmentTypeProductOfferShipmentTypeWritePublisherPlugin(),
             new ShipmentTypeStoreProductOfferShipmentTypeWritePublisherPlugin(),
+        ];
+    }
+    /**
+     * @return array
+     */
+    public function getProductMessageBrokerPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Product\Communication\Plugin\Publisher\ProductConcreteExportedMessageBrokerPublisherPlugin(),
+            new Spryker\Zed\Product\Communication\Plugin\Publisher\ProductConcreteCreatedMessageBrokerPublisherPlugin(),
+            new Spryker\Zed\Product\Communication\Plugin\Publisher\ProductConcreteUpdatedMessageBrokerPublisherPlugin(),
+            new Spryker\Zed\Product\Communication\Plugin\Publisher\ProductConcreteDeletedMessageBrokerPublisherPlugin(),
+            new Spryker\Zed\Product\Communication\Plugin\Publisher\ProductAbstractUpdatedMessageBrokerPublisherPlugin(),
+            new Spryker\Zed\ProductCategory\Communication\Plugin\Publisher\ProductCategoryProductUpdatedEventTriggerPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/Security/SecurityDependencyProvider.php
+++ b/src/Pyz/Zed/Security/SecurityDependencyProvider.php
@@ -24,12 +24,12 @@ class SecurityDependencyProvider extends SprykerSecurityDependencyProvider
     protected function getSecurityPlugins(): array
     {
         return [
-            new UserSessionHandlerSecurityPlugin(),
-            new SystemUserSecurityPlugin(),
-            new MerchantUserSecurityPlugin(),
-            new UserSecurityPlugin(),
-            new OauthUserSecurityPlugin(),
-            new ValidateSessionUserSecurityPlugin(),
+            new Spryker\Zed\User\Communication\Plugin\Security\ZedUserSessionHandlerSecurityPlugin(),
+            new Spryker\Zed\SecuritySystemUser\Communication\Plugin\Security\ZedSystemUserSecurityPlugin(),
+            new Spryker\Zed\SecurityMerchantPortalGui\Communication\Plugin\Security\ZedMerchantUserSecurityPlugin(),
+            new Spryker\Zed\SecurityGui\Communication\Plugin\Security\ZedUserSecurityPlugin(),
+            new Spryker\Zed\SecurityOauthUser\Communication\Plugin\Security\ZedOauthUserSecurityPlugin(),
+            new Spryker\Zed\SessionUserValidation\Communication\Plugin\Security\ZedValidateSessionUserSecurityPlugin(),
             new SaveSessionUserSecurityPlugin(),
         ];
     }

--- a/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
+++ b/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
@@ -12,6 +12,11 @@ use Spryker\Zed\SecurityGui\SecurityGuiConfig as SprykerSecurityGuiConfig;
 class SecurityGuiConfig extends SprykerSecurityGuiConfig
 {
     /**
+     * @var bool
+     */
+    protected const IS_BACKOFFICE_USER_SECURITY_BLOCKER_ENABLED = true;
+
+    /**
      * @var string
      */
     protected const IGNORABLE_ROUTE_PATTERN = '^/(security-gui|health-check|_profiler/wdt|api/rest/.+)';

--- a/src/Pyz/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
+++ b/src/Pyz/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\SecurityMerchantPortalGui;
+
+use Spryker\Zed\SecurityMerchantPortalGui\SecurityMerchantPortalGuiConfig as SprykerSecurityMerchantPortalGuiConfig;
+
+class SecurityMerchantPortalGuiConfig extends SprykerSecurityMerchantPortalGuiConfig
+{
+    /**
+     * @var bool
+     */
+    protected const MERCHANT_PORTAL_SECURITY_BLOCKER_ENABLED = true;
+}

--- a/src/Pyz/Zed/Transfer/TransferConfig.php
+++ b/src/Pyz/Zed/Transfer/TransferConfig.php
@@ -59,4 +59,17 @@ class TransferConfig extends SprykerTransferConfig
     {
         return true;
     }
+    /**
+     * Specification:
+     * - Returns strategy for merging property descriptions.
+     * - Possible values are: TransferConstants::PROPERTY_DESCRIPTION_MERGE_STRATEGY_DEFAULT, TransferConstants::PROPERTY_DESCRIPTION_MERGE_STRATEGY_GET_FIRST, TransferConstants::PROPERTY_DESCRIPTION_MERGE_STRATEGY_MERGE.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getPropertyDescriptionMergeStrategy() : string
+    {
+        return Spryker\Shared\Transfer\TransferConstants::PROPERTY_DESCRIPTION_MERGE_STRATEGY_GET_FIRST;
+    }
 }

--- a/src/Pyz/Zed/Validator/ValidatorDependencyProvider.php
+++ b/src/Pyz/Zed/Validator/ValidatorDependencyProvider.php
@@ -33,7 +33,7 @@ class ValidatorDependencyProvider extends SprykerValidatorDependencyProvider
     protected function getConstraintPlugins(): array
     {
         return [
-            new UserPasswordValidatorConstraintPlugin(),
+            new Spryker\Zed\Security\Communication\Plugin\Validator\ZedUserPasswordValidatorConstraintPlugin(),
         ];
     }
 }


### PR DESCRIPTION
Upgrader installed 3 release group(s) (including 3 security fix(es)) containing 171 package version(s).
| Release | Efforts saved by Upgrader | Warnings detected? |
| ------- | ---- | ------------------ |
| [Fixed Insecure Password Reset Workflow](https://api.release.spryker.com/release-group/5137) |89% |No |
| [Improved controllers input validation.](https://api.release.spryker.com/release-group/5152) |100% |No |
| [Symfony Security 6 Support](https://api.release.spryker.com/release-group/5109) |100% |Yes :warning: |


## Warnings
> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 44
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:44
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(48): {closure}('09f6b2065668336...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit5df24547b73cb365f303cb26a8d05f48::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 44

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 44
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:44
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(48): {closure}('09f6b2065668336...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit5df24547b73cb365f303cb26a8d05f48::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 44

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 44
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:44
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(48): {closure}('09f6b2065668336...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit5df24547b73cb365f303cb26a8d05f48::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 44

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 44
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:44
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(48): {closure}('09f6b2065668336...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit5df24547b73cb365f303cb26a8d05f48::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 44

<details><summary><h4>PHP classes that became not compatible with Spryker Release</h4></summary>Switch to this branch, bootstrap your project in the development environment, open the mentioned file, and compare its correctness to the released version by Spryker.

| Composer command | Project file(s) |
|------------------|-----------------|
| composer update spryker/customer:7.55.0 spryker/http:1.11.0 spryker/oauth-agent-connector:1.2.0 spryker/security:1.8.0 spryker/security-blocker-backoffice-gui:1.1.0 spryker/security-blocker-merchant-portal-gui:1.1.0 spryker/security-gui:1.6.0 spryker/security-merchant-portal-gui:2.3.0 spryker/security-oauth-user:1.4.0 spryker/security-system-user:1.1.0 spryker/session-user-validation:1.4.0 spryker/symfony:3.15.0 spryker/user:3.20.0 spryker-shop/agent-page:1.14.0 spryker-shop/customer-page:2.51.0 spryker-shop/security-blocker-page:1.2.0 spryker-shop/session-agent-validation:1.2.0 spryker-shop/session-customer-validation-page:1.1.0 spryker-shop/store-widget:1.2.0 --no-scripts --no-plugins --no-interaction -w | <b>src</b><br>Cannot detect broken PHP files because PHPStan fails. To check manually, run `vendor/bin/phpstan analyse src/` from project root dir<br> |
| - | <b>src</b><br>Cannot detect broken PHP files because PHPStan fails. To check manually, run `vendor/bin/phpstan analyse src/` from project root dir<br> |

</details>

<details><summary><h4>We were not able to integrate these module versions</h4></summary>

| Package | Version | Message | 
|---------|------|--------|
 | **files** |  P | Error during normalizing files: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 44
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-uuid/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:44
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(48): {closure}('09f6b2065668336...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit5df24547b73cb365f303cb26a8d05f48::getLoader()
#2 /data/project/vendor/squizlabs/php_codesniffer/autoload.php(79): include('/data/project/v...')
#3 /data/project/vendor/squizlabs/php_codesniffer/bin/phpcbf(17): PHP_CodeSniffer\Autoload::load('PHP_CodeSniffer...')
#4 /data/project/vendor/bin/phpcbf(119): include('/data/project/v...')
#5 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 44 | 
</details>


<details><summary><h2>List of packages</h2></summary>

**Packages upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **spryker-shop/customer-page** | 2.47.0 | 2.49.0 | https://github.com/spryker-shop/customer-page/compare/2.47.0...2.49.0 | 
 | **spryker/customer** | 7.52.0 | 7.53.0 | https://github.com/spryker/customer/compare/7.52.0...7.53.0 | 
 | **spryker/security-gui** | 1.4.0 | 1.5.0 | https://github.com/spryker/security-gui/compare/1.4.0...1.5.0 | 
 | **spryker/security-merchant-portal-gui** | 2.1.0 | 2.2.0 | https://github.com/spryker/security-merchant-portal-gui/compare/2.1.0...2.2.0 | 
 | **spryker/user-password-reset** | 1.4.0 | 1.5.0 | https://github.com/spryker/user-password-reset/compare/1.4.0...1.5.0 | 
 | **spryker/state-machine** | 2.19.0 | 2.20.0 | https://github.com/spryker/state-machine/compare/2.19.0...2.20.0 | 
 | **composer/semver** | 3.4.0 | REMOVED |  | 
 | **doctrine/deprecations** | 1.1.2 | 1.1.3 | https://github.com/doctrine/deprecations/compare/1.1.2...1.1.3 | 
 | **doctrine/inflector** | 2.0.8 | 2.0.10 | https://github.com/doctrine/inflector/compare/2.0.8...2.0.10 | 
 | **doctrine/lexer** | 2.1.0 | 2.1.1 | https://github.com/doctrine/lexer/compare/2.1.0...2.1.1 | 
 | **guzzlehttp/guzzle** | 7.8.0 | 7.9.1 | https://github.com/guzzle/guzzle/compare/7.8.0...7.9.1 | 
 | **guzzlehttp/promises** | 2.0.1 | 2.0.3 | https://github.com/guzzle/promises/compare/2.0.1...2.0.3 | 
 | **guzzlehttp/psr7** | 2.6.1 | 2.7.0 | https://github.com/guzzle/psr7/compare/2.6.1...2.7.0 | 
 | **laminas/laminas-filter** | 2.33.0 | 2.36.0 | https://github.com/laminas/laminas-filter/compare/2.33.0...2.36.0 | 
 | **laminas/laminas-stdlib** | 3.18.0 | 3.19.0 | https://github.com/laminas/laminas-stdlib/compare/3.18.0...3.19.0 | 
 | **league/uri** | 7.3.0 | 7.4.1 | https://github.com/thephpleague/uri/compare/7.3.0...7.4.1 | 
 | **league/uri-interfaces** | 7.3.0 | 7.4.1 | https://github.com/thephpleague/uri-interfaces/compare/7.3.0...7.4.1 | 
 | **monolog/monolog** | 2.9.2 | 2.9.3 | https://github.com/Seldaek/monolog/compare/2.9.2...2.9.3 | 
 | **psr/http-factory** | 1.0.2 | 1.1.0 | https://github.com/php-fig/http-factory/compare/1.0.2...1.1.0 | 
 | **ramsey/uuid** | 4.7.4 | 4.7.6 | https://github.com/ramsey/uuid/compare/4.7.4...4.7.6 | 
 | **react/promise** | v2.10.0 | v2.11.0 | https://github.com/reactphp/promise/compare/v2.10.0...v2.11.0 | 
 | **ruflin/elastica** | 7.3.1 | 7.3.2 | https://github.com/ruflin/Elastica/compare/7.3.1...7.3.2 | 
 | **spryker-sdk/evaluator** | 0.1.11 | REMOVED |  | 
 | **spryker-sdk/security-checker** | 0.2.0 | REMOVED |  | 
 | **spryker-shop/agent-page** | 1.13.0 | 1.14.0 | https://github.com/spryker-shop/agent-page/compare/1.13.0...1.14.0 | 
 | **spryker-shop/checkout-page** | 3.29.1 | 3.30.4 | https://github.com/spryker-shop/checkout-page/compare/3.29.1...3.30.4 | 
 | **spryker-shop/customer-page** | 2.49.0 | 2.51.0 | https://github.com/spryker-shop/customer-page/compare/2.49.0...2.51.0 | 
 | **spryker-shop/security-blocker-page** | 1.1.0 | 1.2.0 | https://github.com/spryker-shop/security-blocker-page/compare/1.1.0...1.2.0 | 
 | **spryker-shop/session-agent-validation** | 1.1.0 | 1.2.0 | https://github.com/spryker-shop/session-agent-validation/compare/1.1.0...1.2.0 | 
 | **spryker-shop/session-customer-validation-page** | 1.0.0 | 1.1.0 | https://github.com/spryker-shop/session-customer-validation-page/compare/1.0.0...1.1.0 | 
 | **spryker-shop/shop-ui** | 1.73.0 | 1.75.0 | https://github.com/spryker-shop/shop-ui/compare/1.73.0...1.75.0 | 
 | **spryker-shop/store-widget** | 1.1.0 | 1.2.0 | https://github.com/spryker-shop/store-widget/compare/1.1.0...1.2.0 | 
 | **spryker/acl** | 3.18.0 | 3.20.1 | https://github.com/spryker/acl/compare/3.18.0...3.20.1 | 
 | **spryker/acl-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/acl-extension/compare/1.1.0...1.2.0 | 
 | **spryker/application** | 3.35.0 | 3.35.1 | https://github.com/spryker/application/compare/3.35.0...3.35.1 | 
 | **spryker/availability** | 9.21.0 | 9.22.0 | https://github.com/spryker/availability/compare/9.21.0...9.22.0 | 
 | **spryker/category** | 5.14.0 | 5.17.0 | https://github.com/spryker/category/compare/5.14.0...5.17.0 | 
 | **spryker/cms** | 7.13.0 | 7.14.0 | https://github.com/spryker/cms/compare/7.13.0...7.14.0 | 
 | **spryker/collector** | 6.9.0 | 6.10.1 | https://github.com/spryker/collector/compare/6.9.0...6.10.1 | 
 | **spryker/comment-extension** | 1.0.0 | 1.1.0 | https://github.com/spryker/comment-extension/compare/1.0.0...1.1.0 | 
 | **spryker/console** | 4.12.0 | 4.13.0 | https://github.com/spryker/console/compare/4.12.0...4.13.0 | 
 | **spryker/country** | 4.1.0 | 4.3.0 | https://github.com/spryker/country/compare/4.1.0...4.3.0 | 
 | **spryker/currency** | 4.0.0 | 4.2.0 | https://github.com/spryker/currency/compare/4.0.0...4.2.0 | 
 | **spryker/customer** | 7.53.0 | 7.55.0 | https://github.com/spryker/customer/compare/7.53.0...7.55.0 | 
 | **spryker/customer-access** | 1.3.0 | 1.4.0 | https://github.com/spryker/customer-access/compare/1.3.0...1.4.0 | 
 | **spryker/customer-access-storage** | 1.9.0 | 1.10.0 | https://github.com/spryker/customer-access-storage/compare/1.9.0...1.10.0 | 
 | **spryker/customer-extension** | 1.4.0 | 1.5.0 | https://github.com/spryker/customer-extension/compare/1.4.0...1.5.0 | 
 | **spryker/event-behavior** | 1.27.0 | 1.28.1 | https://github.com/spryker/event-behavior/compare/1.27.0...1.28.1 | 
 | **spryker/glossary** | 3.15.0 | 3.17.0 | https://github.com/spryker/glossary/compare/3.15.0...3.17.0 | 
 | **spryker/gui** | 3.52.0 | 3.53.2 | https://github.com/spryker/gui/compare/3.52.0...3.53.2 | 
 | **spryker/http** | 1.10.0 | 1.11.0 | https://github.com/spryker/http/compare/1.10.0...1.11.0 | 
 | **spryker/kernel** | 3.74.0 | 3.74.4 | https://github.com/spryker/kernel/compare/3.74.0...3.74.4 | 
 | **spryker/locale** | 4.2.0 | 4.6.0 | https://github.com/spryker/locale/compare/4.2.0...4.6.0 | 
 | **spryker/log** | 3.16.0 | 3.17.0 | https://github.com/spryker/log/compare/3.16.0...3.17.0 | 
 | **spryker/merchant-user** | 1.4.0 | 1.6.0 | https://github.com/spryker/merchant-user/compare/1.4.0...1.6.0 | 
 | **spryker/money** | 2.13.0 | 2.13.1 | https://github.com/spryker/money/compare/2.13.0...2.13.1 | 
 | **spryker/oauth-agent-connector** | 1.1.0 | 1.2.0 | https://github.com/spryker/oauth-agent-connector/compare/1.1.0...1.2.0 | 
 | **spryker/oms** | 11.28.0 | 11.33.0 | https://github.com/spryker/oms/compare/11.28.0...11.33.0 | 
 | **spryker/oms-extension** | 1.3.0 | 1.4.0 | https://github.com/spryker/oms-extension/compare/1.3.0...1.4.0 | 
 | **spryker/payment** | 5.15.1 | 5.19.0 | https://github.com/spryker/payment/compare/5.15.1...5.19.0 | 
 | **spryker/price-product** | 4.43.1 | 4.44.1 | https://github.com/spryker/price-product/compare/4.43.1...4.44.1 | 
 | **spryker/product** | 6.38.0 | 6.42.0 | https://github.com/spryker/product/compare/6.38.0...6.42.0 | 
 | **spryker/product-bundle** | 7.17.0 | 7.19.0 | https://github.com/spryker/product-bundle/compare/7.17.0...7.19.0 | 
 | **spryker/product-category** | 4.22.0 | 4.25.0 | https://github.com/spryker/product-category/compare/4.22.0...4.25.0 | 
 | **spryker/product-image** | 3.17.0 | 3.18.0 | https://github.com/spryker/product-image/compare/3.17.0...3.18.0 | 
 | **spryker/product-option** | 8.16.0 | 8.19.0 | https://github.com/spryker/product-option/compare/8.16.0...8.19.0 | 
 | **spryker/product-search** | 5.20.0 | 5.21.1 | https://github.com/spryker/product-search/compare/5.20.0...5.21.1 | 
 | **spryker/propel** | 3.39.0 | 3.40.0 | https://github.com/spryker/propel/compare/3.39.0...3.40.0 | 
 | **spryker/propel-orm** | 1.19.0 | 1.20.0 | https://github.com/spryker/propel-orm/compare/1.19.0...1.20.0 | 
 | **spryker/refund** | 5.7.2 | 5.10.0 | https://github.com/spryker/refund/compare/5.7.2...5.10.0 | 
 | **spryker/router** | 1.18.0 | 1.19.1 | https://github.com/spryker/router/compare/1.18.0...1.19.1 | 
 | **spryker/sales** | 11.42.0 | 11.49.1 | https://github.com/spryker/sales/compare/11.42.0...11.49.1 | 
 | **spryker/sales-extension** | 1.9.0 | 1.11.0 | https://github.com/spryker/sales-extension/compare/1.9.0...1.11.0 | 
 | **spryker/search** | 8.22.0 | 8.23.1 | https://github.com/spryker/search/compare/8.22.0...8.23.1 | 
 | **spryker/security** | 1.7.1 | 1.8.0 | https://github.com/spryker/security/compare/1.7.1...1.8.0 | 
 | **spryker/security-blocker-backoffice-gui** | 1.0.0 | 1.1.0 | https://github.com/spryker/security-blocker-backoffice-gui/compare/1.0.0...1.1.0 | 
 | **spryker/security-blocker-merchant-portal-gui** | 1.0.0 | 1.1.0 | https://github.com/spryker/security-blocker-merchant-portal-gui/compare/1.0.0...1.1.0 | 
 | **spryker/security-gui** | 1.5.0 | 1.6.0 | https://github.com/spryker/security-gui/compare/1.5.0...1.6.0 | 
 | **spryker/security-merchant-portal-gui** | 2.2.0 | 2.3.0 | https://github.com/spryker/security-merchant-portal-gui/compare/2.2.0...2.3.0 | 
 | **spryker/security-merchant-portal-gui-extension** | 1.0.0 | 1.1.0 | https://github.com/spryker/security-merchant-portal-gui-extension/compare/1.0.0...1.1.0 | 
 | **spryker/security-oauth-user** | 1.3.0 | 1.4.0 | https://github.com/spryker/security-oauth-user/compare/1.3.0...1.4.0 | 
 | **spryker/security-system-user** | 1.0.0 | 1.1.0 | https://github.com/spryker/security-system-user/compare/1.0.0...1.1.0 | 
 | **spryker/session-user-validation** | 1.3.0 | 1.4.0 | https://github.com/spryker/session-user-validation/compare/1.3.0...1.4.0 | 
 | **spryker/shipment** | 8.18.0 | 8.22.0 | https://github.com/spryker/shipment/compare/8.18.0...8.22.0 | 
 | **spryker/stock** | 8.8.3 | 8.9.0 | https://github.com/spryker/stock/compare/8.8.3...8.9.0 | 
 | **spryker/storage** | 3.22.0 | 3.22.1 | https://github.com/spryker/storage/compare/3.22.0...3.22.1 | 
 | **spryker/store** | 1.24.0 | 1.27.0 | https://github.com/spryker/store/compare/1.24.0...1.27.0 | 
 | **spryker/symfony** | 3.14.0 | 3.15.0 | https://github.com/spryker/symfony/compare/3.14.0...3.15.0 | 
 | **spryker/tax** | 5.15.0 | 5.16.0 | https://github.com/spryker/tax/compare/5.15.0...5.16.0 | 
 | **spryker/touch** | 4.7.0 | 4.7.1 | https://github.com/spryker/touch/compare/4.7.0...4.7.1 | 
 | **spryker/transfer** | 3.34.0 | 3.36.0 | https://github.com/spryker/transfer/compare/3.34.0...3.36.0 | 
 | **spryker/translator** | 1.12.0 | 1.13.0 | https://github.com/spryker/translator/compare/1.12.0...1.13.0 | 
 | **spryker/twig** | 3.19.0 | 3.23.0 | https://github.com/spryker/twig/compare/3.19.0...3.23.0 | 
 | **spryker/url** | 3.12.0 | 3.14.0 | https://github.com/spryker/url/compare/3.12.0...3.14.0 | 
 | **spryker/user** | 3.19.0 | 3.20.0 | https://github.com/spryker/user/compare/3.19.0...3.20.0 | 
 | **spryker/user-extension** | 1.2.0 | 1.3.0 | https://github.com/spryker/user-extension/compare/1.2.0...1.3.0 | 
 | **spryker/util-date-time** | 1.4.1 | 1.5.0 | https://github.com/spryker/util-date-time/compare/1.4.1...1.5.0 | 
 | **spryker/util-text** | 1.5.1 | 1.6.0 | https://github.com/spryker/util-text/compare/1.5.1...1.6.0 | 
 | **spryker/zed-request** | 3.20.0 | 3.21.0 | https://github.com/spryker/zed-request/compare/3.20.0...3.21.0 | 
 | **spryker/zed-ui** | 2.2.0 | 2.4.1 | https://github.com/spryker/zed-ui/compare/2.2.0...2.4.1 | 
 | **symfony-cmf/routing** | 3.0.1 | 3.0.3 | https://github.com/symfony-cmf/Routing/compare/3.0.1...3.0.3 | 
 | **symfony/cache** | v6.3.6 | REMOVED |  | 
 | **symfony/cache-contracts** | v3.3.0 | REMOVED |  | 
 | **symfony/clock** | v6.3.4 | v6.4.8 | https://github.com/symfony/clock/compare/v6.3.4...v6.4.8 | 
 | **symfony/config** | v6.3.2 | v6.4.8 | https://github.com/symfony/config/compare/v6.3.2...v6.4.8 | 
 | **symfony/console** | v6.3.4 | v6.4.9 | https://github.com/symfony/console/compare/v6.3.4...v6.4.9 | 
 | **symfony/dependency-injection** | v6.3.5 | REMOVED |  | 
 | **symfony/deprecation-contracts** | v3.3.0 | v3.5.0 | https://github.com/symfony/deprecation-contracts/compare/v3.3.0...v3.5.0 | 
 | **symfony/dotenv** | v6.3.7 | REMOVED |  | 
 | **symfony/error-handler** | v6.3.5 | v6.3.12 | https://github.com/symfony/error-handler/compare/v6.3.5...v6.3.12 | 
 | **symfony/event-dispatcher** | v6.3.2 | v6.4.8 | https://github.com/symfony/event-dispatcher/compare/v6.3.2...v6.4.8 | 
 | **symfony/event-dispatcher-contracts** | v3.3.0 | v3.5.0 | https://github.com/symfony/event-dispatcher-contracts/compare/v3.3.0...v3.5.0 | 
 | **symfony/filesystem** | v6.3.1 | v6.4.9 | https://github.com/symfony/filesystem/compare/v6.3.1...v6.4.9 | 
 | **symfony/finder** | v6.3.5 | v6.4.8 | https://github.com/symfony/finder/compare/v6.3.5...v6.4.8 | 
 | **symfony/flex** | v2.4.1 | REMOVED |  | 
 | **symfony/form** | v6.3.7 | v6.4.8 | https://github.com/symfony/form/compare/v6.3.7...v6.4.8 | 
 | **symfony/framework-bundle** | v6.3.7 | REMOVED |  | 
 | **symfony/http-client** | v6.3.7 | v6.4.9 | https://github.com/symfony/http-client/compare/v6.3.7...v6.4.9 | 
 | **symfony/http-client-contracts** | v3.3.0 | v3.5.0 | https://github.com/symfony/http-client-contracts/compare/v3.3.0...v3.5.0 | 
 | **symfony/http-foundation** | v6.3.7 | v6.4.8 | https://github.com/symfony/http-foundation/compare/v6.3.7...v6.4.8 | 
 | **symfony/intl** | v6.3.7 | v6.4.8 | https://github.com/symfony/intl/compare/v6.3.7...v6.4.8 | 
 | **symfony/messenger** | v6.3.7 | v6.4.9 | https://github.com/symfony/messenger/compare/v6.3.7...v6.4.9 | 
 | **symfony/mime** | v6.3.5 | v6.4.9 | https://github.com/symfony/mime/compare/v6.3.5...v6.4.9 | 
 | **symfony/monolog-bridge** | v5.4.22 | REMOVED |  | 
 | **symfony/monolog-bundle** | v3.9.0 | REMOVED |  | 
 | **symfony/options-resolver** | v6.3.0 | v6.4.8 | https://github.com/symfony/options-resolver/compare/v6.3.0...v6.4.8 | 
 | **symfony/password-hasher** | v6.3.5 | v6.4.8 | https://github.com/symfony/password-hasher/compare/v6.3.5...v6.4.8 | 
 | **symfony/polyfill-intl-grapheme** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-intl-grapheme/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-intl-icu** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-intl-icu/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-intl-idn** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-intl-idn/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-intl-normalizer** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-intl-normalizer/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-mbstring** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-mbstring/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-php73** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-php73/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-php80** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-php80/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-php83** | v1.28.0 | v1.30.0 | https://github.com/symfony/polyfill-php83/compare/v1.28.0...v1.30.0 | 
 | **symfony/polyfill-uuid** | v1.28.0 | REMOVED |  | 
 | **symfony/process** | v6.3.4 | v6.4.8 | https://github.com/symfony/process/compare/v6.3.4...v6.4.8 | 
 | **symfony/property-access** | v6.3.2 | v6.4.8 | https://github.com/symfony/property-access/compare/v6.3.2...v6.4.8 | 
 | **symfony/property-info** | v6.3.0 | v6.4.9 | https://github.com/symfony/property-info/compare/v6.3.0...v6.4.9 | 
 | **symfony/routing** | v6.3.5 | v6.4.8 | https://github.com/symfony/routing/compare/v6.3.5...v6.4.8 | 
 | **symfony/runtime** | v6.3.2 | REMOVED |  | 
 | **symfony/security-core** | v5.4.30 | v6.4.9 | https://github.com/symfony/security-core/compare/v5.4.30...v6.4.9 | 
 | **symfony/security-csrf** | v6.3.2 | v6.4.8 | https://github.com/symfony/security-csrf/compare/v6.3.2...v6.4.8 | 
 | **symfony/security-guard** | v5.4.27 | v5.4.0-BETA1 | https://github.com/symfony/security-guard/compare/v5.4.27...v5.4.0-BETA1 | 
 | **symfony/security-http** | v5.4.31 | v6.4.9 | https://github.com/symfony/security-http/compare/v5.4.31...v6.4.9 | 
 | **symfony/serializer** | v6.3.7 | v6.4.9 | https://github.com/symfony/serializer/compare/v6.3.7...v6.4.9 | 
 | **symfony/service-contracts** | v2.5.2 | v3.5.0 | https://github.com/symfony/service-contracts/compare/v2.5.2...v3.5.0 | 
 | **symfony/stopwatch** | v6.3.0 | v6.4.8 | https://github.com/symfony/stopwatch/compare/v6.3.0...v6.4.8 | 
 | **symfony/string** | v6.3.5 | v6.4.9 | https://github.com/symfony/string/compare/v6.3.5...v6.4.9 | 
 | **symfony/translation** | v6.3.7 | v6.4.8 | https://github.com/symfony/translation/compare/v6.3.7...v6.4.8 | 
 | **symfony/translation-contracts** | v3.3.0 | v3.5.0 | https://github.com/symfony/translation-contracts/compare/v3.3.0...v3.5.0 | 
 | **symfony/twig-bridge** | v6.3.8 | v6.3.12 | https://github.com/symfony/twig-bridge/compare/v6.3.8...v6.3.12 | 
 | **symfony/uid** | v6.3.0 | REMOVED |  | 
 | **symfony/validator** | v6.3.7 | v6.4.9 | https://github.com/symfony/validator/compare/v6.3.7...v6.4.9 | 
 | **symfony/var-dumper** | v6.3.6 | v6.4.9 | https://github.com/symfony/var-dumper/compare/v6.3.6...v6.4.9 | 
 | **symfony/var-exporter** | v6.3.6 | REMOVED |  | 
 | **symfony/yaml** | v6.3.7 | v6.4.8 | https://github.com/symfony/yaml/compare/v6.3.7...v6.4.8 | 
 | **twig/twig** | v3.7.1 | v3.8.0 | https://github.com/twigphp/Twig/compare/v3.7.1...v3.8.0 | 
 | **webmozart/glob** | 4.6.0 | 4.7.0 | https://github.com/webmozarts/glob/compare/4.6.0...4.7.0 | 
 | **spryker/log-extension** | NEW | 1.0.0 |  | 
 | **symfony/polyfill-ctype** | NEW | v1.30.0 |  | 
 | **symfony/polyfill-iconv** | NEW | v1.30.0 |  | 
 | **symfony/polyfill-php72** | NEW | v1.30.0 |  | 

**Packages dev upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **phpdocumentor/reflection-docblock** | 5.3.0 | 5.4.1 | https://github.com/phpDocumentor/ReflectionDocBlock/compare/5.3.0...5.4.1 | 
 | **phpdocumentor/type-resolver** | 1.7.3 | 1.8.2 | https://github.com/phpDocumentor/TypeResolver/compare/1.7.3...1.8.2 | 
 | **phpstan/phpdoc-parser** | 1.24.2 | 1.29.1 | https://github.com/phpstan/phpdoc-parser/compare/1.24.2...1.29.1 | 
 | **symfony/cache** | NEW | v6.3.6 |  | 
 | **symfony/cache-contracts** | NEW | v3.5.0 |  | 
 | **symfony/dependency-injection** | NEW | v6.3.5 |  | 
 | **symfony/framework-bundle** | NEW | v6.3.7 |  | 
 | **symfony/var-exporter** | NEW | v6.3.6 |  | 

</details>


### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/ca/devscu/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: fb3b8af7-b98f-4cf9-8b96-a7117ecfd8c8